### PR TITLE
CSS Caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "babel-core": "^5.2.9",
     "btoa": "^1.1.2",
     "coffee-script": "^1.9.2",
+    "less": "^2.5.0",
     "lodash": "^3.8.0",
     "mkdirp": "^0.5.0",
     "ncp": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lodash": "^3.8.0",
     "mkdirp": "^0.5.0",
     "ncp": "^2.0.0",
+    "node-sass": "^3.1.1",
     "promise": "^7.0.1",
     "rimraf": "^2.3.3",
     "typescript-simple": "^1.0.3",

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -14,6 +14,7 @@ export default class CompileCache {
     
     this.cacheDir = null;
     this.jsCacheDir = null;
+    this.seenFilePaths = {};
   }
     
   getCompilerInformation() {
@@ -24,7 +25,7 @@ export default class CompileCache {
     throw new Error("Implement this in a derived class");
   }
   
-  shouldCompileFile(sourceCode) {
+  shouldCompileFile(sourceCode, fullPath) {
     return true;
   }
   
@@ -114,9 +115,12 @@ export default class CompileCache {
   // Returns the transpiled version of the JavaScript code at filePath, which is
   // either generated on the fly or pulled from cache.
   loadFile(module, filePath, returnOnly=false) {
+    let fullPath = path.resolve(filePath);
+    this.seenFilePaths[path.dirname(filePath)] = true;
+    
     const sourceCode = fs.readFileSync(filePath, 'utf8');
     
-    if (!this.shouldCompileFile(sourceCode)) {
+    if (!this.shouldCompileFile(sourceCode, fullPath)) {
       if (returnOnly) return sourceCode;
       
       return module._compile(sourceCode, filePath);

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -130,7 +130,7 @@ export default class CompileCache {
     let js = this.getCachedJavaScript(cachePath);
     
     if (!js) {
-      js = this.compile(sourceCode, filePath);
+      js = this.compile(sourceCode, filePath, cachePath);
       this.stats.misses++;
       
       fs.writeFileSync(cachePath, js);

--- a/src/css/less.js
+++ b/src/css/less.js
@@ -41,7 +41,6 @@ export default class LessCompiler extends CompileCache {
       filename: path.basename(filePath)
     });
     
-    console.log(`Rendering LESS with Opts: ${opts}`);
     lessjs.render(sourceCode, opts, (err, out) => {
       // NB: Because we've forced less to work in sync mode, we can do this
       if (err) throw err;

--- a/src/css/less.js
+++ b/src/css/less.js
@@ -1,0 +1,64 @@
+'use babel';
+
+import _ from 'lodash';
+import path from 'path';
+import CompileCache from '../compile-cache';
+
+let lessjs = null;
+
+const lessFileExtensions = /\.less$/i;
+
+export default class LessCompiler extends CompileCache {
+  constructor(options={}) {
+    super();
+    
+    const defaultOptions = {
+        compress: false, 
+        sourcemap: { sourcemapfileinline: true }
+    };
+    
+    const requiredOptions = { 
+        fileAsync: false,
+        async: false
+    };
+    
+    this.compilerInformation = _.extend(defaultOptions, options, requiredOptions);
+  }
+    
+  getCompilerInformation() {
+    return this.compilerInformation;
+  }
+  
+  compile(sourceCode, filePath) {
+    this.ensureLess();
+    
+    let source = '';
+    let paths = Object.keys(this.seenFilePaths);
+    paths.unshift('.');
+    
+    let opts = _.extend({}, this.compilerInformation, {
+      paths: paths,
+      filename: path.basename(filePath)
+    });
+    
+    console.log(`Rendering LESS with Opts: ${opts}`);
+    lessjs.render(sourceCode, opts, (err, out) => {
+      // NB: Because we've forced less to work in sync mode, we can do this
+      if (err) throw err;
+      source = out.css;
+    });
+    
+    return source;
+  }
+  
+  shouldCompileFile(sourceCode, filePath) {
+    return filePath.match(lessFileExtensions);
+  }
+  
+  ensureLess() {
+    if (!lessjs) {
+      lessjs = require('less');
+      this.compilerInformation.version = require('less/package.json').version;
+    }
+  }
+}

--- a/src/css/scss.js
+++ b/src/css/scss.js
@@ -1,0 +1,58 @@
+'use babel';
+
+import _ from 'lodash';
+import path from 'path';
+import CompileCache from '../compile-cache';
+
+let scss = null;
+
+const scssFileExtensions = /\.(sass|scss)$/i;
+
+export default class ScssCompiler extends CompileCache {
+  constructor(options={}) {
+    super();
+    
+    const defaultOptions = {
+      sourceComments: true,
+      sourceMapEmbed: true,
+      sourceMapContents: true,
+    };
+    
+    const requiredOptions = { };
+    
+    this.compilerInformation = _.extend(defaultOptions, options, requiredOptions);
+  }
+    
+  getCompilerInformation() {
+    return this.compilerInformation;
+  }
+  
+  compile(sourceCode, filePath) {
+    this.ensureScss();
+    
+    let paths = Object.keys(this.seenFilePaths);
+    paths.unshift('.');
+    
+    let opts = _.extend({}, this.compilerInformation, {
+      data: sourceCode,
+      indentedSyntax: filePath.match(/\.sass$/i),
+      sourceMapRoot: filePath,
+      includePaths: paths,
+      filename: path.basename(filePath)
+    });
+    
+    let result = scss.renderSync(opts);
+    return result.toString('utf8');
+  }
+  
+  shouldCompileFile(sourceCode, filePath) {
+    return filePath.match(scssFileExtensions);
+  }
+  
+  ensureScss() {
+    if (!scss) {
+      scss = require('node-sass');
+      this.compilerInformation.version = require('node-sass/package.json').version;
+    }
+  }
+}

--- a/src/js/babel.js
+++ b/src/js/babel.js
@@ -1,7 +1,7 @@
 'use babel';
 
 import _ from 'lodash';
-import CompileCache from './compile-cache';
+import CompileCache from '../compile-cache';
 
 let babel = null;
 

--- a/src/js/coffeescript.js
+++ b/src/js/coffeescript.js
@@ -2,8 +2,9 @@
 
 import _ from 'lodash';
 import path from 'path';
-import CompileCache from './compile-cache';
 import btoa from 'btoa';
+
+import CompileCache from '../compile-cache';
 
 let coffee = null;
 

--- a/src/js/typescript.js
+++ b/src/js/typescript.js
@@ -1,7 +1,7 @@
 'use babel';
 
 import _ from 'lodash';
-import CompileCache from './compile-cache';
+import CompileCache from '../compile-cache';
 
 let tss = null;
 

--- a/test/compile-cache.js
+++ b/test/compile-cache.js
@@ -1,93 +1,10 @@
 require('./support.js');
 
-import BabelCompiler from '../lib/babel';
-import TypeScriptCompiler from '../lib/typescript';
-import CoffeeScriptCompiler from '../lib/coffeescript';
-import fs from 'fs';
 import path from 'path';
 import rimraf from 'rimraf';
 
-describe('The CoffeeScript Compiler', function() {
-  it('should compile valid CoffeeScript', function() {
-    let fixture = new CoffeeScriptCompiler();
-    
-    let input = path.join(__dirname, '..', 'test', 'fixtures', 'valid.coffee');
-    let result = fixture.compile(fs.readFileSync(input, 'utf8'));
-    
-    expect(result.length > 0).to.be.ok;
-  });
-  
-  it('should fail on invalid CoffeeScript', function() {
-    let fixture = new CoffeeScriptCompiler();
-    
-    let input = path.join(__dirname, '..', 'test', 'fixtures', 'invalid.coffee');
-    
-    let shouldDie = true;
-    try {
-      let result = fixture.compile(fs.readFileSync(input, 'utf8'));
-      console.log(result);
-    } catch (e) {
-      shouldDie = false;
-    }
-    
-    expect(shouldDie).not.to.be.ok;
-  });
-});
-
-
-describe('The Babel Compiler', function() {
-  it('should compile itself', function() {
-    let fixture = new BabelCompiler();
-    
-    let input = require.resolve('../src/babel.js');
-    let result = fixture.compile(fs.readFileSync(input, 'utf8'));
-    
-    expect(result.length > 0).to.be.ok;
-  });
-  
-  it('should fail on bogus input', function() {
-    let fixture = new BabelCompiler();
-    
-    let input = require.resolve('../src/babel.js');
-    
-    let shouldDie = true;
-    try {
-      let result = fixture.compile(fs.readFileSync(input, 'utf8') + "\n\n!@!@!@!@!@!@!@!;");
-      console.log(result);
-    } catch (e) {
-      shouldDie = false;
-    }
-    
-    expect(shouldDie).not.to.be.ok;
-  });
-});
-
-describe('The TypeScript Compiler', function() {
-  it('should compile valid TypeScript', function() {
-    let fixture = new TypeScriptCompiler();
-    
-    let input = path.join(__dirname, '..', 'test', 'fixtures', 'valid.ts');
-    let result = fixture.compile(fs.readFileSync(input, 'utf8'));
-    
-    expect(result.length > 0).to.be.ok;
-  });
-  
-  it('should fail on invalid TypeScript', function() {
-    let fixture = new TypeScriptCompiler();
-    
-    let input = path.join(__dirname, '..', 'test', 'fixtures', 'invalid.ts');
-    
-    let shouldDie = true;
-    try {
-      let result = fixture.compile(fs.readFileSync(input, 'utf8'));
-      console.log(result);
-    } catch (e) {
-      shouldDie = false;
-    }
-    
-    expect(shouldDie).not.to.be.ok;
-  });
-});
+import BabelCompiler from '../lib/js/babel';
+import TypeScriptCompiler from '../lib/js/typescript';
 
 describe('The compile cache', function() {
   it('Should only call compile once for the same file', function() {
@@ -99,7 +16,7 @@ describe('The compile cache', function() {
     fixture.setCacheDirectory(cacheDir);
     
     try {
-      let input = require.resolve('../src/babel.js');
+      let input = require.resolve('../src/js/babel.js');
       let result = fixture.loadFile(module, input, true);
       
       expect(result.length > 0).to.be.ok;

--- a/test/css-compilers.js
+++ b/test/css-compilers.js
@@ -1,0 +1,33 @@
+require('./support.js');
+
+import fs from 'fs';
+import path from 'path';
+
+import LessCompiler from '../lib/css/less';
+
+describe('The LESS Compiler', function() {
+  it('should compile valid LESS', function() {
+    let fixture = new LessCompiler();
+    
+    let input = path.join(__dirname, '..', 'test', 'fixtures', 'valid.less');
+    let result = fixture.compile(fs.readFileSync(input, 'utf8'));
+    
+    expect(result.length > 0).to.be.ok;
+  });
+  
+  it('should fail on invalid LESS', function() {
+    let fixture = new LessCompiler();
+    
+    let input = path.join(__dirname, '..', 'test', 'fixtures', 'invalid.less');
+    
+    let shouldDie = true;
+    try {
+      let result = fixture.compile(fs.readFileSync(input, 'utf8'));
+      console.log(result);
+    } catch (e) {
+      shouldDie = false;
+    }
+    
+    expect(shouldDie).not.to.be.ok;
+  });
+});

--- a/test/css-compilers.js
+++ b/test/css-compilers.js
@@ -33,11 +33,38 @@ describe('The LESS Compiler', function() {
   });
 });
 
+describe('The SCSS Compiler', function() {
+  it('should compile valid SCSS', function() {
+    let fixture = new ScssCompiler();
+    
+    let input = path.join(__dirname, '..', 'test', 'fixtures', 'valid.scss');
+    let result = fixture.compile(fs.readFileSync(input, 'utf8'), input);
+    
+    expect(result.length > 0).to.be.ok;
+  });
+  
+  it('should fail on invalid SCSS', function() {
+    let fixture = new ScssCompiler();
+    
+    let input = path.join(__dirname, '..', 'test', 'fixtures', 'invalid.scss');
+    
+    let shouldDie = true;
+    try {
+      let result = fixture.compile(fs.readFileSync(input, 'utf8'), input);
+      console.log(result);
+    } catch (e) {
+      shouldDie = false;
+    }
+    
+    expect(shouldDie).not.to.be.ok;
+  });
+});
+
 describe('The Sass Compiler', function() {
   it('should compile valid Sass', function() {
     let fixture = new ScssCompiler();
     
-    let input = path.join(__dirname, '..', 'test', 'fixtures', 'valid.scss');
+    let input = path.join(__dirname, '..', 'test', 'fixtures', 'valid.sass');
     let result = fixture.compile(fs.readFileSync(input, 'utf8'), input);
     
     expect(result.length > 0).to.be.ok;

--- a/test/css-compilers.js
+++ b/test/css-compilers.js
@@ -4,13 +4,14 @@ import fs from 'fs';
 import path from 'path';
 
 import LessCompiler from '../lib/css/less';
+import ScssCompiler from '../lib/css/scss';
 
 describe('The LESS Compiler', function() {
   it('should compile valid LESS', function() {
     let fixture = new LessCompiler();
     
     let input = path.join(__dirname, '..', 'test', 'fixtures', 'valid.less');
-    let result = fixture.compile(fs.readFileSync(input, 'utf8'));
+    let result = fixture.compile(fs.readFileSync(input, 'utf8'), input);
     
     expect(result.length > 0).to.be.ok;
   });
@@ -22,7 +23,34 @@ describe('The LESS Compiler', function() {
     
     let shouldDie = true;
     try {
-      let result = fixture.compile(fs.readFileSync(input, 'utf8'));
+      let result = fixture.compile(fs.readFileSync(input, 'utf8'), input);
+      console.log(result);
+    } catch (e) {
+      shouldDie = false;
+    }
+    
+    expect(shouldDie).not.to.be.ok;
+  });
+});
+
+describe('The Sass Compiler', function() {
+  it('should compile valid Sass', function() {
+    let fixture = new ScssCompiler();
+    
+    let input = path.join(__dirname, '..', 'test', 'fixtures', 'valid.scss');
+    let result = fixture.compile(fs.readFileSync(input, 'utf8'), input);
+    
+    expect(result.length > 0).to.be.ok;
+  });
+  
+  it('should fail on invalid Sass', function() {
+    let fixture = new ScssCompiler();
+    
+    let input = path.join(__dirname, '..', 'test', 'fixtures', 'invalid.sass');
+    
+    let shouldDie = true;
+    try {
+      let result = fixture.compile(fs.readFileSync(input, 'utf8'), input);
       console.log(result);
     } catch (e) {
       shouldDie = false;

--- a/test/fixtures/invalid.less
+++ b/test/fixtures/invalid.less
@@ -1,0 +1,1 @@
+@bodyColor: darken(@bodyColor, 30%);

--- a/test/fixtures/invalid.sass
+++ b/test/fixtures/invalid.sass
@@ -1,0 +1,5 @@
+/* this has curly braces! */
+#navbar {
+  width: 80%;
+  height: 23px;
+}

--- a/test/fixtures/invalid.scss
+++ b/test/fixtures/invalid.scss
@@ -1,0 +1,3 @@
+body {
+  background-color: $green;
+}

--- a/test/fixtures/valid.less
+++ b/test/fixtures/valid.less
@@ -1,0 +1,6 @@
+@nice-blue: #5B83AD;
+@light-blue: @nice-blue + #111;
+
+#header {
+  color: @light-blue;
+}

--- a/test/fixtures/valid.sass
+++ b/test/fixtures/valid.sass
@@ -1,0 +1,10 @@
+#main
+  color: blue
+  font-size: 0.3em
+
+  a
+    font:
+      weight: bold
+      family: serif
+    &:hover
+      background-color: #eee

--- a/test/fixtures/valid.scss
+++ b/test/fixtures/valid.scss
@@ -1,0 +1,16 @@
+#navbar {
+  width: 80%;
+  height: 23px;
+}
+
+#navbar ul {
+  list-style-type: none;
+}
+
+#navbar li {
+  float: left;
+
+  a {
+    font-weight: bold;
+  }
+}

--- a/test/javascript-compilers.js
+++ b/test/javascript-compilers.js
@@ -1,0 +1,90 @@
+require('./support.js');
+
+import fs from 'fs';
+import path from 'path';
+
+import BabelCompiler from '../lib/js/babel';
+import TypeScriptCompiler from '../lib/js/typescript';
+import CoffeeScriptCompiler from '../lib/js/coffeescript';
+
+describe('The CoffeeScript Compiler', function() {
+  it('should compile valid CoffeeScript', function() {
+    let fixture = new CoffeeScriptCompiler();
+    
+    let input = path.join(__dirname, '..', 'test', 'fixtures', 'valid.coffee');
+    let result = fixture.compile(fs.readFileSync(input, 'utf8'));
+    
+    expect(result.length > 0).to.be.ok;
+  });
+  
+  it('should fail on invalid CoffeeScript', function() {
+    let fixture = new CoffeeScriptCompiler();
+    
+    let input = path.join(__dirname, '..', 'test', 'fixtures', 'invalid.coffee');
+    
+    let shouldDie = true;
+    try {
+      let result = fixture.compile(fs.readFileSync(input, 'utf8'));
+      console.log(result);
+    } catch (e) {
+      shouldDie = false;
+    }
+    
+    expect(shouldDie).not.to.be.ok;
+  });
+});
+
+
+describe('The Babel Compiler', function() {
+  it('should compile itself', function() {
+    let fixture = new BabelCompiler();
+    
+    let input = require.resolve('../src/js/babel.js');
+    let result = fixture.compile(fs.readFileSync(input, 'utf8'));
+    
+    expect(result.length > 0).to.be.ok;
+  });
+  
+  it('should fail on bogus input', function() {
+    let fixture = new BabelCompiler();
+    
+    let input = require.resolve('../src/js/babel.js');
+    
+    let shouldDie = true;
+    try {
+      let result = fixture.compile(fs.readFileSync(input, 'utf8') + "\n\n!@!@!@!@!@!@!@!;");
+      console.log(result);
+    } catch (e) {
+      shouldDie = false;
+    }
+    
+    expect(shouldDie).not.to.be.ok;
+  });
+});
+
+describe('The TypeScript Compiler', function() {
+  it('should compile valid TypeScript', function() {
+    let fixture = new TypeScriptCompiler();
+    
+    let input = path.join(__dirname, '..', 'test', 'fixtures', 'valid.ts');
+    let result = fixture.compile(fs.readFileSync(input, 'utf8'));
+    
+    expect(result.length > 0).to.be.ok;
+  });
+  
+  it('should fail on invalid TypeScript', function() {
+    let fixture = new TypeScriptCompiler();
+    
+    let input = path.join(__dirname, '..', 'test', 'fixtures', 'invalid.ts');
+    
+    let shouldDie = true;
+    try {
+      let result = fixture.compile(fs.readFileSync(input, 'utf8'));
+      console.log(result);
+    } catch (e) {
+      shouldDie = false;
+    }
+    
+    expect(shouldDie).not.to.be.ok;
+  });
+});


### PR DESCRIPTION
This PR adds support for Sass/SCSS/LESS caching of CSS content. We don’t actually wire up “Registration” of SCSS because that isn’t an actual thing, we’ll do that in a separate PR.