### PR TITLE
Register compilers with node and Electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Electron supporting package to compile JS and CSS in Electron applications",
   "main": "lib/main.js",
   "scripts": {
-    "compile": "babel --stage 0 -d lib/ src/ && babel --stage 0 -d test-dist/ test/",
+    "compile": "babel --stage 0 -d lib/ src/ && babel --stage 0 --only test/*.js -d test-dist/ test/",
     "prepublish": "npm run compile",
     "test": "npm run compile && mocha test-dist/*"
   },

--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
     "prepublish": "npm run compile",
     "test": "npm run compile && mocha test-dist/*"
   },
-  "bin": {
-    "electron-run": "lib/cli.js"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/paulcbetts/electron-devmode"

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -12,35 +12,39 @@ export default class CompileCache {
       hits: 0,
       misses: 0
     };
-    
+
     this.cacheDir = null;
     this.jsCacheDir = null;
     this.seenFilePaths = {};
   }
-    
+
   getCompilerInformation() {
     throw new Error("Implement this in a derived class");
   }
-  
+
   compile(sourceCode, filePath, cachePath) {
     throw new Error("Implement this in a derived class");
   }
-  
+
   getMimeType() {
     throw new Error("Implement this in a derived class");
   }
-  
+
+  initializeCompiler() {
+    throw new Error("Implement this in a derived class");
+  }
+
   shouldCompileFile(sourceCode, fullPath) {
     this.ensureInitialized();
     let lowerPath = fullPath.toLowerCase();
-    
-    // NB: require() normally does this for us, but in our protocol hook we 
+
+    // NB: require() normally does this for us, but in our protocol hook we
     // need to do this ourselves
     return _.some(
-      this.extensions, 
+      this.extensions,
       (ext) => lowerPath.lastIndexOf(ext) + ext.length === lowerPath.length);
   }
-  
+
   ///
   /// shasum - Hash with an update() method.
   /// value - Must be a value that could be returned by JSON.parse().
@@ -51,24 +55,24 @@ export default class CompileCache {
     // * No effort is made to avoid trailing commas.
     // These shortcuts should not affect the correctness of this function.
     const type = typeof(value);
-    
+
     if (type === 'string') {
       shasum.update('"', 'utf8');
       shasum.update(value, 'utf8');
       shasum.update('"', 'utf8');
       return;
     }
-    
+
     if (type === 'boolean' || type === 'number') {
       shasum.update(value.toString(), 'utf8');
       return;
     }
-    
+
     if (value === null) {
       shasum.update('null', 'utf8');
       return;
     }
-    
+
     if (Array.isArray(value)) {
       shasum.update('[', 'utf8');
       for (let i=0; i < value.length; i++) {
@@ -78,20 +82,20 @@ export default class CompileCache {
       shasum.update(']', 'utf8');
       return;
     }
-    
+
     // value must be an object: be sure to sort the keys.
     let keys = Object.keys(value);
     keys.sort();
 
     shasum.update('{', 'utf8');
-    
+
     for (let i=0; i < keys.length; i++) {
       this.updateDigestForJsonValue(shasum, keys[i]);
       shasum.update(': ', 'utf8');
       this.updateDigestForJsonValue(shasum, value[keys[i]]);
       shasum.update(',', 'utf8');
     }
-    
+
     shasum.update('}', 'utf8');
   }
 
@@ -100,7 +104,7 @@ export default class CompileCache {
     this.updateDigestForJsonValue(sha1, this.getCompilerInformation());
     return sha1.digest('hex');
   }
-  
+
   getCachePath(sourceCode) {
     let digest = crypto.createHash('sha1').update(sourceCode, 'utf8').digest('hex');
 
@@ -116,46 +120,46 @@ export default class CompileCache {
     try {
       let ret = fs.readFileSync(cachePath, 'utf8');
       this.stats.hits++;
-      
+
       return ret;
     } catch (e) {
       return null;
     }
   }
-  
+
   // Function that obeys the contract of an entry in the require.extensions map.
   // Returns the transpiled version of the JavaScript code at filePath, which is
   // either generated on the fly or pulled from cache.
   loadFile(module, filePath, returnOnly=false, sourceCode=null) {
     this.ensureInitialized();
-    
+
     let fullPath = path.resolve(filePath);
     this.seenFilePaths[path.dirname(filePath)] = true;
-    
+
     sourceCode = sourceCode || fs.readFileSync(filePath, 'utf8');
-    
+
     if (!this.shouldCompileFile(sourceCode, fullPath)) {
       if (returnOnly) return sourceCode;
       return module._compile(sourceCode, filePath);
     }
-    
+
     let cachePath = this.getCachePath(sourceCode);
     let js = this.getCachedJavaScript(cachePath);
-    
+
     if (!js) {
       js = this.compile(sourceCode, filePath, cachePath);
       this.stats.misses++;
-      
+
       fs.writeFileSync(cachePath, js);
-    } 
-    
+    }
+
     if (returnOnly) return js;
     return module._compile(js, filePath);
   }
-  
+
   register() {
     this.ensureInitialized();
-    
+
     for (let i=0; i < this.extensions.length; i++) {
       Object.defineProperty(require.extensions, `.${this.extensions[i]}`, {
         enumerable: true,
@@ -164,22 +168,22 @@ export default class CompileCache {
       });
     }
   }
-  
+
   ensureInitialized() {
     if (this.extensions) return;
-    
+
     let info = this.getCompilerInformation();
-    
+
     if (!info.extension && !info.extensions) {
       throw new Error("Compiler must register at least one extension in getCompilerInformation");
     }
-    
+
     this.extensions = (info.extensions ? info.extensions : [info.extension]);
   }
-  
+
   setCacheDirectory(newCacheDir) {
     if (this.cacheDir === newCacheDir) return;
-    
+
     this.cacheDir = newCacheDir;
     this.jsCacheDir = null;
   }

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -127,6 +127,10 @@ export default class CompileCache {
     }
   }
 
+  saveCachedJavaScript(cachePath, js) {
+    fs.writeFileSync(cachePath, js);
+  }
+
   // Function that obeys the contract of an entry in the require.extensions map.
   // Returns the transpiled version of the JavaScript code at filePath, which is
   // either generated on the fly or pulled from cache.
@@ -157,7 +161,7 @@ export default class CompileCache {
       js = this.compile(sourceCode, filePath, cachePath);
       this.stats.misses++;
 
-      fs.writeFileSync(cachePath, js);
+      this.saveCachedJavaScript(cachePath, js);
     }
 
     if (returnOnly) return js;

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -26,6 +26,10 @@ export default class CompileCache {
     throw new Error("Implement this in a derived class");
   }
   
+  getMimeType() {
+    throw new Error("Implement this in a derived class");
+  }
+  
   shouldCompileFile(sourceCode, fullPath) {
     this.ensureInitialized();
     let lowerPath = fullPath.toLowerCase();

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -143,6 +143,13 @@ export default class CompileCache {
       return module._compile(sourceCode, filePath);
     }
 
+    // NB: We do all of these backflips in order to not load compilers unless
+    // we actually end up using them, since loading them is typically fairly
+    // expensive
+    if (!this.compilerInformation.version) {
+      this.compilerInformation.version = this.initializeCompiler();
+    }
+
     let cachePath = this.getCachePath(sourceCode);
     let js = this.getCachedJavaScript(cachePath);
 

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -126,13 +126,13 @@ export default class CompileCache {
   // Function that obeys the contract of an entry in the require.extensions map.
   // Returns the transpiled version of the JavaScript code at filePath, which is
   // either generated on the fly or pulled from cache.
-  loadFile(module, filePath, returnOnly=false) {
+  loadFile(module, filePath, returnOnly=false, sourceCode=null) {
     this.ensureInitialized();
     
     let fullPath = path.resolve(filePath);
     this.seenFilePaths[path.dirname(filePath)] = true;
     
-    const sourceCode = fs.readFileSync(filePath, 'utf8');
+    sourceCode = sourceCode || fs.readFileSync(filePath, 'utf8');
     
     if (!this.shouldCompileFile(sourceCode, fullPath)) {
       if (returnOnly) return sourceCode;

--- a/src/css/less.js
+++ b/src/css/less.js
@@ -11,62 +11,50 @@ const lessFileExtensions = /\.less$/i;
 export default class LessCompiler extends CompileCache {
   constructor(options={}) {
     super();
-    
+
     const defaultOptions = {
-      compress: false, 
+      compress: false,
       sourcemap: { sourcemapfileinline: true }
     };
-    
-    const requiredOptions = { 
+
+    const requiredOptions = {
       extension: 'less',
       fileAsync: false,
       async: false
     };
-    
+
     this.compilerInformation = _.extend(defaultOptions, options, requiredOptions);
   }
-    
+
   getCompilerInformation() {
     return this.compilerInformation;
   }
-  
+
   compile(sourceCode, filePath) {
-    this.ensureLess();
-    
     let source = '';
     let paths = Object.keys(this.seenFilePaths);
     paths.unshift('.');
-    
+
     let opts = _.extend({}, this.compilerInformation, {
       paths: paths,
       filename: path.basename(filePath)
     });
-    
+
     lessjs.render(sourceCode, opts, (err, out) => {
       // NB: Because we've forced less to work in sync mode, we can do this
       if (err) throw err;
       source = out.css;
     });
-    
+
     return source;
   }
-  
+
   getMimeType() { return 'text/css'; }
-  
-  shouldCompileFile(sourceCode, fullPath) {
-    let ret = super.shouldCompileFile(sourceCode, fullPath);
-    if (!ret) return ret;
-    
-    this.ensureLess();
-    return ret;
-  }
-  
+
   register() {}
-  
-  ensureLess() {
-    if (!lessjs) {
-      lessjs = require('less');
-      this.compilerInformation.version = require('less/package.json').version;
-    }
+
+  initializeCompiler() {
+    lessjs = require('less');
+    return require('less/package.json').version;
   }
 }

--- a/src/css/less.js
+++ b/src/css/less.js
@@ -13,13 +13,14 @@ export default class LessCompiler extends CompileCache {
     super();
     
     const defaultOptions = {
-        compress: false, 
-        sourcemap: { sourcemapfileinline: true }
+      compress: false, 
+      sourcemap: { sourcemapfileinline: true }
     };
     
     const requiredOptions = { 
-        fileAsync: false,
-        async: false
+      extension: 'less',
+      fileAsync: false,
+      async: false
     };
     
     this.compilerInformation = _.extend(defaultOptions, options, requiredOptions);
@@ -53,6 +54,8 @@ export default class LessCompiler extends CompileCache {
   shouldCompileFile(sourceCode, filePath) {
     return filePath.match(lessFileExtensions);
   }
+  
+  register() {}
   
   ensureLess() {
     if (!lessjs) {

--- a/src/css/less.js
+++ b/src/css/less.js
@@ -53,8 +53,12 @@ export default class LessCompiler extends CompileCache {
   
   getMimeType() { return 'text/css'; }
   
-  shouldCompileFile(sourceCode, filePath) {
-    return filePath.match(lessFileExtensions);
+  shouldCompileFile(sourceCode, fullPath) {
+    let ret = super.shouldCompileFile(sourceCode, fullPath);
+    if (!ret) return ret;
+    
+    this.ensureLess();
+    return ret;
   }
   
   register() {}

--- a/src/css/less.js
+++ b/src/css/less.js
@@ -51,6 +51,8 @@ export default class LessCompiler extends CompileCache {
     return source;
   }
   
+  getMimeType() { return 'text/css'; }
+  
   shouldCompileFile(sourceCode, filePath) {
     return filePath.match(lessFileExtensions);
   }

--- a/src/css/scss.js
+++ b/src/css/scss.js
@@ -46,12 +46,16 @@ export default class ScssCompiler extends CompileCache {
     let result = scss.renderSync(opts);
     return result.toString('utf8');
   }
+   
+  shouldCompileFile(sourceCode, fullPath) {
+    let ret = super.shouldCompileFile(sourceCode, fullPath);
+    if (!ret) return ret;
+    
+    this.ensureScss();
+    return ret;
+  }
   
   getMimeType() { return 'text/css'; }
-  
-  shouldCompileFile(sourceCode, filePath) {
-    return filePath.match(scssFileExtensions);
-  }
   
   register() {}
   

--- a/src/css/scss.js
+++ b/src/css/scss.js
@@ -18,7 +18,9 @@ export default class ScssCompiler extends CompileCache {
       sourceMapContents: true,
     };
     
-    const requiredOptions = { };
+    const requiredOptions = { 
+      extensions: ['scss', 'sass']
+    };
     
     this.compilerInformation = _.extend(defaultOptions, options, requiredOptions);
   }
@@ -48,6 +50,8 @@ export default class ScssCompiler extends CompileCache {
   shouldCompileFile(sourceCode, filePath) {
     return filePath.match(scssFileExtensions);
   }
+  
+  register() {}
   
   ensureScss() {
     if (!scss) {

--- a/src/css/scss.js
+++ b/src/css/scss.js
@@ -47,6 +47,8 @@ export default class ScssCompiler extends CompileCache {
     return result.toString('utf8');
   }
   
+  getMimeType() { return 'text/css'; }
+  
   shouldCompileFile(sourceCode, filePath) {
     return filePath.match(scssFileExtensions);
   }

--- a/src/css/scss.js
+++ b/src/css/scss.js
@@ -11,30 +11,28 @@ const scssFileExtensions = /\.(sass|scss)$/i;
 export default class ScssCompiler extends CompileCache {
   constructor(options={}) {
     super();
-    
+
     const defaultOptions = {
       sourceComments: true,
       sourceMapEmbed: true,
       sourceMapContents: true,
     };
-    
-    const requiredOptions = { 
+
+    const requiredOptions = {
       extensions: ['scss', 'sass']
     };
-    
+
     this.compilerInformation = _.extend(defaultOptions, options, requiredOptions);
   }
-    
+
   getCompilerInformation() {
     return this.compilerInformation;
   }
-  
+
   compile(sourceCode, filePath) {
-    this.ensureScss();
-    
     let paths = Object.keys(this.seenFilePaths);
     paths.unshift('.');
-    
+
     let opts = _.extend({}, this.compilerInformation, {
       data: sourceCode,
       indentedSyntax: filePath.match(/\.sass$/i),
@@ -42,27 +40,17 @@ export default class ScssCompiler extends CompileCache {
       includePaths: paths,
       filename: path.basename(filePath)
     });
-    
+
     let result = scss.renderSync(opts);
     return result.toString('utf8');
   }
-   
-  shouldCompileFile(sourceCode, fullPath) {
-    let ret = super.shouldCompileFile(sourceCode, fullPath);
-    if (!ret) return ret;
-    
-    this.ensureScss();
-    return ret;
-  }
-  
+
   getMimeType() { return 'text/css'; }
-  
+
   register() {}
-  
-  ensureScss() {
-    if (!scss) {
-      scss = require('node-sass');
-      this.compilerInformation.version = require('node-sass/package.json').version;
-    }
+
+  initializeCompiler() {
+    scss = require('node-sass');
+    return require('node-sass/package.json').version;
   }
 }

--- a/src/js/babel.js
+++ b/src/js/babel.js
@@ -37,6 +37,8 @@ export default class BabelCompiler extends CompileCache {
     return babel.transform(sourceCode, this.babelCompilerOpts).code;
   }
   
+  getMimeType() { return 'text/javascript'; }
+  
   shouldCompileFile(sourceCode, filePath) {
     let ret = super.shouldCompileFile(sourceCode, filePath);
     return ret && /^("use babel"|'use babel'|"use babel"|'use babel')/.test(sourceCode);

--- a/src/js/babel.js
+++ b/src/js/babel.js
@@ -24,7 +24,6 @@ export default class BabelCompiler extends CompileCache {
         'asyncToGenerator'
       ],
     }, options);
-    
   }
     
   getCompilerInformation() {
@@ -38,9 +37,9 @@ export default class BabelCompiler extends CompileCache {
     return babel.transform(sourceCode, this.babelCompilerOpts).code;
   }
   
-  shouldCompileFile(sourceCode) {
-    this.ensureBabel();
-    return /^("use babel"|'use babel'|"use babel"|'use babel')/.test(sourceCode);
+  shouldCompileFile(sourceCode, filePath) {
+    let ret = super.shouldCompileFile(sourceCode, filePath);
+    return ret && /^("use babel"|'use babel'|"use babel"|'use babel')/.test(sourceCode);
   }
   
   ensureBabel() {

--- a/src/js/babel.js
+++ b/src/js/babel.js
@@ -10,7 +10,7 @@ const validOpts = ['sourceMap', 'blacklist', 'stage', 'optional'];
 export default class BabelCompiler extends CompileCache {
   constructor(options={}) {
     super();
-    
+
     this.compilerInformation = _.extend({}, {
       extension: 'js',
       sourceMap: 'inline',
@@ -25,32 +25,27 @@ export default class BabelCompiler extends CompileCache {
       ],
     }, options);
   }
-    
+
   getCompilerInformation() {
     return this.compilerInformation;
   }
-  
+
   compile(sourceCode) {
-    this.ensureBabel();
     this.babelCompilerOpts = this.babelCompilerOpts || _.pick(this.compilerInformation, validOpts);
-    
     return babel.transform(sourceCode, this.babelCompilerOpts).code;
   }
-  
+
   getMimeType() { return 'text/javascript'; }
-  
+
   shouldCompileFile(sourceCode, filePath) {
     let ret = super.shouldCompileFile(sourceCode, filePath);
     if (!ret) return;
-    
-    this.ensureBabel();
+
     return ret && /^("use babel"|'use babel'|"use babel"|'use babel')/.test(sourceCode);
   }
-  
-  ensureBabel() {
-    if (!babel) {
-      babel = require('babel-core');
-      this.compilerInformation.version = babel.version;
-    }
+
+  initializeCompiler() {
+    babel = require('babel-core');
+    return babel.version;
   }
 }

--- a/src/js/babel.js
+++ b/src/js/babel.js
@@ -41,6 +41,9 @@ export default class BabelCompiler extends CompileCache {
   
   shouldCompileFile(sourceCode, filePath) {
     let ret = super.shouldCompileFile(sourceCode, filePath);
+    if (!ret) return;
+    
+    this.ensureBabel();
     return ret && /^("use babel"|'use babel'|"use babel"|'use babel')/.test(sourceCode);
   }
   

--- a/src/js/coffeescript.js
+++ b/src/js/coffeescript.js
@@ -32,6 +32,8 @@ export default class CoffeeScriptCompiler extends CompileCache {
     return js;
   }
   
+  getMimeType() { return 'text/javascript'; }
+  
   shouldCompileFile() {
     this.ensureCoffee();
     return true;

--- a/src/js/coffeescript.js
+++ b/src/js/coffeescript.js
@@ -11,49 +11,38 @@ let coffee = null;
 export default class CoffeeScriptCompiler extends CompileCache {
   constructor(options={}) {
     super();
-    
+
     this.compilerInformation = _.extend({}, {
       extension: 'coffee',
     }, options);
   }
-    
+
   getCompilerInformation() {
     return this.compilerInformation;
   }
-  
+
   compile(sourceCode, filePath) {
-    this.ensureCoffee();
     let {js, v3SourceMap} = coffee.compile(sourceCode, { filename: filePath, sourceMap: true });
-    
+
     js = `${js}\n` +
       `//# sourceMappingURL=data:application/json;base64,${btoa(unescape(encodeURIComponent(v3SourceMap)))}\n` +
       `//# sourceURL=${this.convertFilePath(filePath)}`;
-      
+
     return js;
   }
-  
+
   getMimeType() { return 'text/javascript'; }
-  
-  shouldCompileFile(sourceCode, fullPath) {
-    let ret = super.shouldCompileFile(sourceCode, fullPath);
-    if (!ret) return ret;
-    
-    this.ensureCoffee();
-    return ret;
+
+  initializeCompiler() {
+    coffee = require('coffee-script');
+    return require('coffee-script/package.json').version;
   }
-  
-  ensureCoffee() {
-    if (!coffee) {
-      coffee = require('coffee-script');
-      this.compilerInformation.version = require('coffee-script/package.json').version;
-    }
-  }
-  
+
   convertFilePath(filePath) {
     if (process.platform === 'win32') {
       filePath = `/${path.resolve(filePath).replace(/\\/g, '/')}`;
     }
-      
+
     return encodeURI(filePath);
   }
 }

--- a/src/js/coffeescript.js
+++ b/src/js/coffeescript.js
@@ -34,9 +34,12 @@ export default class CoffeeScriptCompiler extends CompileCache {
   
   getMimeType() { return 'text/javascript'; }
   
-  shouldCompileFile() {
+  shouldCompileFile(sourceCode, fullPath) {
+    let ret = super.shouldCompileFile(sourceCode, fullPath);
+    if (!ret) return ret;
+    
     this.ensureCoffee();
-    return true;
+    return ret;
   }
   
   ensureCoffee() {

--- a/src/js/typescript.js
+++ b/src/js/typescript.js
@@ -25,6 +25,8 @@ export default class TypeScriptCompiler extends CompileCache {
     this.ensureTs();
     return tss.compile(sourceCode, filePath);
   }
+  
+  getMimeType() { return 'text/javascript'; }
 
   ensureTs() {
     if (!tss) {

--- a/src/js/typescript.js
+++ b/src/js/typescript.js
@@ -25,12 +25,7 @@ export default class TypeScriptCompiler extends CompileCache {
     this.ensureTs();
     return tss.compile(sourceCode, filePath);
   }
-  
-  shouldCompileFile() {
-    this.ensureTs();
-    return true;
-  }
-  
+
   ensureTs() {
     if (!tss) {
       const {TypeScriptSimple} = require('typescript-simple');

--- a/src/js/typescript.js
+++ b/src/js/typescript.js
@@ -26,6 +26,14 @@ export default class TypeScriptCompiler extends CompileCache {
     return tss.compile(sourceCode, filePath);
   }
   
+  shouldCompileFile(sourceCode, fullPath) {
+    let ret = super.shouldCompileFile(sourceCode, fullPath);
+    if (!ret) return ret;
+    
+    this.ensureTs();
+    return ret;
+  }
+  
   getMimeType() { return 'text/javascript'; }
 
   ensureTs() {

--- a/src/js/typescript.js
+++ b/src/js/typescript.js
@@ -8,7 +8,7 @@ let tss = null;
 export default class TypeScriptCompiler extends CompileCache {
   constructor(options={}) {
     super();
-    
+
     this.compilerInformation = _.extend({}, {
       extension: 'ts',
       target: 1,
@@ -16,32 +16,21 @@ export default class TypeScriptCompiler extends CompileCache {
       sourceMap: true
     }, options);
   }
-    
+
   getCompilerInformation() {
     return this.compilerInformation;
   }
-  
+
   compile(sourceCode, filePath) {
-    this.ensureTs();
     return tss.compile(sourceCode, filePath);
   }
-  
-  shouldCompileFile(sourceCode, fullPath) {
-    let ret = super.shouldCompileFile(sourceCode, fullPath);
-    if (!ret) return ret;
-    
-    this.ensureTs();
-    return ret;
-  }
-  
+
   getMimeType() { return 'text/javascript'; }
 
-  ensureTs() {
-    if (!tss) {
-      const {TypeScriptSimple} = require('typescript-simple');
-      tss = new TypeScriptSimple(this.compilerInformation, false);
-      
-      this.compilerInformation.version = require('typescript-simple/package.json').version;
-    }
+  initializeCompiler() {
+    const {TypeScriptSimple} = require('typescript-simple');
+    tss = new TypeScriptSimple(this.compilerInformation, false);
+
+    return require('typescript-simple/package.json').version;
   }
 }

--- a/test/css-compilers.js
+++ b/test/css-compilers.js
@@ -1,88 +1,46 @@
 require('./support.js');
 
-import fs from 'fs';
 import path from 'path';
 
-import LessCompiler from '../lib/css/less';
-import ScssCompiler from '../lib/css/scss';
+const toTest = [
+  { require: '../lib/css/less', extension: 'less' },
+  { require: '../lib/css/scss', extension: 'scss' },
+  { require: '../lib/css/scss', extension: 'sass' },
+];
 
-describe('The LESS Compiler', function() {
-  it('should compile valid LESS', function() {
-    let fixture = new LessCompiler();
-    
-    let input = path.join(__dirname, '..', 'test', 'fixtures', 'valid.less');
-    let result = fixture.compile(fs.readFileSync(input, 'utf8'), input);
-    
-    expect(result.length > 0).to.be.ok;
-  });
-  
-  it('should fail on invalid LESS', function() {
-    let fixture = new LessCompiler();
-    
-    let input = path.join(__dirname, '..', 'test', 'fixtures', 'invalid.less');
-    
-    let shouldDie = true;
-    try {
-      let result = fixture.compile(fs.readFileSync(input, 'utf8'), input);
-      console.log(result);
-    } catch (e) {
-      shouldDie = false;
-    }
-    
-    expect(shouldDie).not.to.be.ok;
-  });
-});
+for (let compiler of toTest) {
+  const Klass = require(compiler.require);
 
-describe('The SCSS Compiler', function() {
-  it('should compile valid SCSS', function() {
-    let fixture = new ScssCompiler();
-    
-    let input = path.join(__dirname, '..', 'test', 'fixtures', 'valid.scss');
-    let result = fixture.compile(fs.readFileSync(input, 'utf8'), input);
-    
-    expect(result.length > 0).to.be.ok;
-  });
-  
-  it('should fail on invalid SCSS', function() {
-    let fixture = new ScssCompiler();
-    
-    let input = path.join(__dirname, '..', 'test', 'fixtures', 'invalid.scss');
-    
-    let shouldDie = true;
-    try {
-      let result = fixture.compile(fs.readFileSync(input, 'utf8'), input);
-      console.log(result);
-    } catch (e) {
-      shouldDie = false;
-    }
-    
-    expect(shouldDie).not.to.be.ok;
-  });
-});
+  describe(`The ${compiler.require} compiler`, function() {
+    it(`should compile valid.${compiler.extension}`, function() {
+      let fixture = new Klass();
 
-describe('The Sass Compiler', function() {
-  it('should compile valid Sass', function() {
-    let fixture = new ScssCompiler();
-    
-    let input = path.join(__dirname, '..', 'test', 'fixtures', 'valid.sass');
-    let result = fixture.compile(fs.readFileSync(input, 'utf8'), input);
-    
-    expect(result.length > 0).to.be.ok;
+      let input = path.join(__dirname, '..', 'test', 'fixtures', `valid.${compiler.extension}`);
+      fixture.getCachedJavaScript = () => null;
+      fixture.saveCachedJavaScript = () => {};
+      fixture.getCachePath = () => 'cache.txt';
+
+      let result = fixture.loadFile(null, input, true);
+      expect(result.length > 0).to.be.ok;
+    });
+
+    it(`should fail on invalid.${compiler.extension}`, function() {
+      let fixture = new Klass();
+
+      let input = path.join(__dirname, '..', 'test', 'fixtures', `invalid.${compiler.extension}`);
+      fixture.getCachedJavaScript = () => null;
+      fixture.saveCachedJavaScript = () => {};
+      fixture.getCachePath = () => 'cache.txt';
+
+      let shouldDie = true;
+      try {
+        let result = fixture.loadFile(null, input, true);
+        console.log(result);
+      } catch (e) {
+        shouldDie = false;
+      }
+
+      expect(shouldDie).not.to.be.ok;
+    });
   });
-  
-  it('should fail on invalid Sass', function() {
-    let fixture = new ScssCompiler();
-    
-    let input = path.join(__dirname, '..', 'test', 'fixtures', 'invalid.sass');
-    
-    let shouldDie = true;
-    try {
-      let result = fixture.compile(fs.readFileSync(input, 'utf8'), input);
-      console.log(result);
-    } catch (e) {
-      shouldDie = false;
-    }
-    
-    expect(shouldDie).not.to.be.ok;
-  });
-});
+}

--- a/test/fixtures/invalid.js
+++ b/test/fixtures/invalid.js
@@ -1,0 +1,3 @@
+'use babel';
+
+WAOEIFKAOWEFKAWOEF@#@#@#@#@#@

--- a/test/fixtures/valid.js
+++ b/test/fixtures/valid.js
@@ -1,0 +1,201 @@
+'use babel';
+
+import crypto from 'crypto';
+import path from 'path';
+import fs from 'fs';
+import mkdirp from 'mkdirp';
+import _ from 'lodash';
+
+export default class CompileCache {
+  constructor() {
+    this.stats = {
+      hits: 0,
+      misses: 0
+    };
+
+    this.cacheDir = null;
+    this.jsCacheDir = null;
+    this.seenFilePaths = {};
+  }
+
+  getCompilerInformation() {
+    throw new Error("Implement this in a derived class");
+  }
+
+  compile(sourceCode, filePath, cachePath) {
+    throw new Error("Implement this in a derived class");
+  }
+
+  getMimeType() {
+    throw new Error("Implement this in a derived class");
+  }
+
+  initializeCompiler() {
+    throw new Error("Implement this in a derived class");
+  }
+
+  shouldCompileFile(sourceCode, fullPath) {
+    this.ensureInitialized();
+    let lowerPath = fullPath.toLowerCase();
+
+    // NB: require() normally does this for us, but in our protocol hook we
+    // need to do this ourselves
+    return _.some(
+      this.extensions,
+      (ext) => lowerPath.lastIndexOf(ext) + ext.length === lowerPath.length);
+  }
+
+  ///
+  /// shasum - Hash with an update() method.
+  /// value - Must be a value that could be returned by JSON.parse().
+  ///
+  updateDigestForJsonValue(shasum, value) {
+    // Implmentation is similar to that of pretty-printing a JSON object, except:
+    // * Strings are not escaped.
+    // * No effort is made to avoid trailing commas.
+    // These shortcuts should not affect the correctness of this function.
+    const type = typeof(value);
+
+    if (type === 'string') {
+      shasum.update('"', 'utf8');
+      shasum.update(value, 'utf8');
+      shasum.update('"', 'utf8');
+      return;
+    }
+
+    if (type === 'boolean' || type === 'number') {
+      shasum.update(value.toString(), 'utf8');
+      return;
+    }
+
+    if (value === null) {
+      shasum.update('null', 'utf8');
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      shasum.update('[', 'utf8');
+      for (let i=0; i < value.length; i++) {
+        this.updateDigestForJsonValue(shasum, value[i]);
+        shasum.update(',', 'utf8');
+      }
+      shasum.update(']', 'utf8');
+      return;
+    }
+
+    // value must be an object: be sure to sort the keys.
+    let keys = Object.keys(value);
+    keys.sort();
+
+    shasum.update('{', 'utf8');
+
+    for (let i=0; i < keys.length; i++) {
+      this.updateDigestForJsonValue(shasum, keys[i]);
+      shasum.update(': ', 'utf8');
+      this.updateDigestForJsonValue(shasum, value[keys[i]]);
+      shasum.update(',', 'utf8');
+    }
+
+    shasum.update('}', 'utf8');
+  }
+
+  createDigestForCompilerInformation() {
+    let sha1 = crypto.createHash('sha1');
+    this.updateDigestForJsonValue(sha1, this.getCompilerInformation());
+    return sha1.digest('hex');
+  }
+
+  getCachePath(sourceCode) {
+    let digest = crypto.createHash('sha1').update(sourceCode, 'utf8').digest('hex');
+
+    if (!this.jsCacheDir) {
+      this.jsCacheDir = path.join(this.cacheDir, this.createDigestForCompilerInformation());
+      mkdirp.sync(this.jsCacheDir);
+    }
+
+    return path.join(this.jsCacheDir, `${digest}.js`);
+  }
+
+  getCachedJavaScript(cachePath) {
+    try {
+      let ret = fs.readFileSync(cachePath, 'utf8');
+      this.stats.hits++;
+
+      return ret;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  saveCachedJavaScript(cachePath, js) {
+    fs.writeFileSync(cachePath, js);
+  }
+
+  // Function that obeys the contract of an entry in the require.extensions map.
+  // Returns the transpiled version of the JavaScript code at filePath, which is
+  // either generated on the fly or pulled from cache.
+  loadFile(module, filePath, returnOnly=false, sourceCode=null) {
+    this.ensureInitialized();
+
+    let fullPath = path.resolve(filePath);
+    this.seenFilePaths[path.dirname(filePath)] = true;
+
+    sourceCode = sourceCode || fs.readFileSync(filePath, 'utf8');
+
+    if (!this.shouldCompileFile(sourceCode, fullPath)) {
+      if (returnOnly) return sourceCode;
+      return module._compile(sourceCode, filePath);
+    }
+
+    // NB: We do all of these backflips in order to not load compilers unless
+    // we actually end up using them, since loading them is typically fairly
+    // expensive
+    if (!this.compilerInformation.version) {
+      this.compilerInformation.version = this.initializeCompiler();
+    }
+
+    let cachePath = this.getCachePath(sourceCode);
+    let js = this.getCachedJavaScript(cachePath);
+
+    if (!js) {
+      js = this.compile(sourceCode, filePath, cachePath);
+      this.stats.misses++;
+
+      this.saveCachedJavaScript(cachePath, js);
+    }
+
+    if (returnOnly) return js;
+    return module._compile(js, filePath);
+  }
+
+  register() {
+    this.ensureInitialized();
+
+    for (let i=0; i < this.extensions.length; i++) {
+      Object.defineProperty(require.extensions, `.${this.extensions[i]}`, {
+        enumerable: true,
+        writable: false,
+        value: (module, filePath) => this.loadFile(module, filePath)
+      });
+    }
+  }
+
+  ensureInitialized() {
+    if (this.extensions) return;
+
+    let info = this.getCompilerInformation();
+
+    if (!info.extension && !info.extensions) {
+      throw new Error("Compiler must register at least one extension in getCompilerInformation");
+    }
+
+    this.extensions = (info.extensions ? info.extensions : [info.extension]);
+  }
+
+  setCacheDirectory(newCacheDir) {
+    if (this.cacheDir === newCacheDir) return;
+
+    this.cacheDir = newCacheDir;
+    this.jsCacheDir = null;
+  }
+}

--- a/test/javascript-compilers.js
+++ b/test/javascript-compilers.js
@@ -3,88 +3,45 @@ require('./support.js');
 import fs from 'fs';
 import path from 'path';
 
-import BabelCompiler from '../lib/js/babel';
-import TypeScriptCompiler from '../lib/js/typescript';
-import CoffeeScriptCompiler from '../lib/js/coffeescript';
+const toTest = [
+  { require: '../lib/js/babel', extension: 'js' },
+  { require: '../lib/js/typescript', extension: 'ts' },
+  { require: '../lib/js/coffeescript', extension: 'coffee' },
+];
 
-describe('The CoffeeScript Compiler', function() {
-  it('should compile valid CoffeeScript', function() {
-    let fixture = new CoffeeScriptCompiler();
-    
-    let input = path.join(__dirname, '..', 'test', 'fixtures', 'valid.coffee');
-    let result = fixture.compile(fs.readFileSync(input, 'utf8'));
-    
-    expect(result.length > 0).to.be.ok;
-  });
-  
-  it('should fail on invalid CoffeeScript', function() {
-    let fixture = new CoffeeScriptCompiler();
-    
-    let input = path.join(__dirname, '..', 'test', 'fixtures', 'invalid.coffee');
-    
-    let shouldDie = true;
-    try {
-      let result = fixture.compile(fs.readFileSync(input, 'utf8'));
-      console.log(result);
-    } catch (e) {
-      shouldDie = false;
-    }
-    
-    expect(shouldDie).not.to.be.ok;
-  });
-});
+for (let compiler of toTest) {
+  const Klass = require(compiler.require);
 
+  describe(`The ${compiler.require} compiler`, function() {
+    it(`should compile valid.${compiler.extension}`, function() {
+      let fixture = new Klass();
 
-describe('The Babel Compiler', function() {
-  it('should compile itself', function() {
-    let fixture = new BabelCompiler();
-    
-    let input = require.resolve('../src/js/babel.js');
-    let result = fixture.compile(fs.readFileSync(input, 'utf8'));
-    
-    expect(result.length > 0).to.be.ok;
-  });
-  
-  it('should fail on bogus input', function() {
-    let fixture = new BabelCompiler();
-    
-    let input = require.resolve('../src/js/babel.js');
-    
-    let shouldDie = true;
-    try {
-      let result = fixture.compile(fs.readFileSync(input, 'utf8') + "\n\n!@!@!@!@!@!@!@!;");
-      console.log(result);
-    } catch (e) {
-      shouldDie = false;
-    }
-    
-    expect(shouldDie).not.to.be.ok;
-  });
-});
+      let input = path.join(__dirname, '..', 'test', 'fixtures', `valid.${compiler.extension}`);
+      fixture.getCachedJavaScript = () => null;
+      fixture.saveCachedJavaScript = () => {};
+      fixture.getCachePath = () => 'cache.txt';
 
-describe('The TypeScript Compiler', function() {
-  it('should compile valid TypeScript', function() {
-    let fixture = new TypeScriptCompiler();
-    
-    let input = path.join(__dirname, '..', 'test', 'fixtures', 'valid.ts');
-    let result = fixture.compile(fs.readFileSync(input, 'utf8'));
-    
-    expect(result.length > 0).to.be.ok;
+      let result = fixture.loadFile(null, input, true);
+      expect(result.length > 0).to.be.ok;
+    });
+
+    it(`should fail on invalid.${compiler.extension}`, function() {
+      let fixture = new Klass();
+
+      let input = path.join(__dirname, '..', 'test', 'fixtures', `invalid.${compiler.extension}`);
+      fixture.getCachedJavaScript = () => null;
+      fixture.saveCachedJavaScript = () => {};
+      fixture.getCachePath = () => 'cache.txt';
+
+      let shouldDie = true;
+      try {
+        let result = fixture.loadFile(null, input, true);
+        console.log(result);
+      } catch (e) {
+        shouldDie = false;
+      }
+
+      expect(shouldDie).not.to.be.ok;
+    });
   });
-  
-  it('should fail on invalid TypeScript', function() {
-    let fixture = new TypeScriptCompiler();
-    
-    let input = path.join(__dirname, '..', 'test', 'fixtures', 'invalid.ts');
-    
-    let shouldDie = true;
-    try {
-      let result = fixture.compile(fs.readFileSync(input, 'utf8'));
-      console.log(result);
-    } catch (e) {
-      shouldDie = false;
-    }
-    
-    expect(shouldDie).not.to.be.ok;
-  });
-});
+}


### PR DESCRIPTION
This PR adds a main method `init()` that sets up our cross-compilers:

* For io.js, we set up require hooks, similar to how Babel and CoffeeScript work natively
* For Electron, we take over the `file:` protocol and check paths to determine whether we should cross-compile CSS/JS. This means that files can be directly included in HTML and we can compile it on-the-fly, regardless of how it was included in the project (i.e. via script tag, document.createElement trickery, HTML imports, etc etc).

This PR also cleans up the compiler plugin classes so that they are less fiddly to write