### PR TITLE
AOT compile code if asked

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,4 @@
 {
-  "es5": true,
   "esnext": true,
   "eqeqeq": true,
   "eqnull": true,

--- a/package.json
+++ b/package.json
@@ -8,9 +8,12 @@
     "prepublish": "npm run compile",
     "test": "npm run compile && mocha test-dist/*"
   },
+  "bin": {
+    "electron-compile": "lib/cli.js"
+  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/paulcbetts/electron-devmode"
+    "url": "https://github.com/paulcbetts/electron-compile"
   },
   "keywords": [
     "electron"
@@ -18,9 +21,9 @@
   "author": "Paul Betts <paul@paulbetts.org>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/paulcbetts/electron-devmode/issues"
+    "url": "https://github.com/paulcbetts/electron-compile/issues"
   },
-  "homepage": "https://github.com/paulcbetts/electron-devmode",
+  "homepage": "https://github.com/paulcbetts/electron-compile",
   "dependencies": {
     "babel-core": "^5.5.4",
     "btoa": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/paulcbetts/electron-compile",
   "dependencies": {
-    "babel-core": "^5.5.4",
+    "babel-core": "^5.6.15",
     "btoa": "^1.1.2",
     "coffee-script": "^1.9.2",
     "less": "^2.5.0",
@@ -39,7 +39,7 @@
     "yargs": "^3.8.0"
   },
   "devDependencies": {
-    "babel": "^5.5.4",
+    "babel": "^5.6.14",
     "chai": "^2.3.0",
     "chai-as-promised": "^5.0.0",
     "chai-spies": "^0.6.0",

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+import {compile, init} from './main';
+import forAllFiles from './for-all-files';
+
+const yargs = require('yargs')
+  .usage('Usage: electron-compile --target [target-path] [source-path]')
+  .alias('t', 'target')
+  .describe('t', 'The target directory to write a cache directory to')
+  .alias('v', 'verbose')
+  .describe('v', 'Print verbose information')
+  .help('h')
+  .alias('h', 'help')
+  .epilog('Copyright 2015');
+  
+const argv = yargs.argv;
+
+if (!argv._ || argv._.length !== 1) {
+  yargs.showHelp();
+  process.exit(-1);
+}
+
+const sourceDir = argv._[0];
+const targetDir = argv.t || './cache';
+
+let allSucceeded = true;
+init(targetDir, true);
+forAllFiles(sourceDir, (f) => {
+  if (argv.v) console.log(`Compiling ${f}...`);
+  try {
+    compile(f);
+  } catch (e) {
+    console.error(`Failed to compile ${f}!`);
+    console.error(e.message);
+    
+    if (argv.v) console.error(e.stack);
+    console.error("\n");
+    allSucceeded = false;
+  }
+});
+
+process.exit(allSucceeded ? 0 : -1);

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,9 +2,10 @@
 
 import {compile, init} from './main';
 import forAllFiles from './for-all-files';
+import _ from 'lodash';
 
 const yargs = require('yargs')
-  .usage('Usage: electron-compile --target [target-path] [source-path]')
+  .usage('Usage: electron-compile --target [target-path] paths...')
   .alias('t', 'target')
   .describe('t', 'The target directory to write a cache directory to')
   .alias('v', 'verbose')
@@ -15,28 +16,31 @@ const yargs = require('yargs')
   
 const argv = yargs.argv;
 
-if (!argv._ || argv._.length !== 1) {
+if (!argv._ || argv._.length < 1) {
   yargs.showHelp();
   process.exit(-1);
 }
 
-const sourceDir = argv._[0];
+const sourceDirs = argv._;
 const targetDir = argv.t || './cache';
 
 let allSucceeded = true;
 init(targetDir, true);
-forAllFiles(sourceDir, (f) => {
-  if (argv.v) console.log(`Compiling ${f}...`);
-  try {
-    compile(f);
-  } catch (e) {
-    console.error(`Failed to compile ${f}!`);
-    console.error(e.message);
-    
-    if (argv.v) console.error(e.stack);
-    console.error("\n");
-    allSucceeded = false;
-  }
+
+_.each(sourceDirs, (sourceDir) => {
+  forAllFiles(sourceDir, (f) => {
+    if (argv.v) console.log(`Compiling ${f}...`);
+    try {
+      compile(f);
+    } catch (e) {
+      console.error(`Failed to compile ${f}!`);
+      console.error(e.message);
+      
+      if (argv.v) console.error(e.stack);
+      console.error("\n");
+      allSucceeded = false;
+    }
+  });
 });
 
 process.exit(allSucceeded ? 0 : -1);

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -36,6 +36,9 @@ export default class CompileCache {
     this.ensureInitialized();
     let lowerPath = fullPath.toLowerCase();
 
+    // If we're in node_modules, we're gonna punt
+    if (fullPath.match(/[\\\/]node_modules[\\\/]/i)) return false;
+
     // NB: require() normally does this for us, but in our protocol hook we
     // need to do this ourselves
     return _.some(

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -111,7 +111,7 @@ export default class CompileCache {
       mkdirp.sync(this.jsCacheDir);
     }
 
-    return path.join(this.jsCacheDir, `${digest}.js`);
+    return path.join(this.jsCacheDir, `${digest}`);
   }
 
   getCachedJavaScript(cachePath) {

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -152,14 +152,20 @@ export default class CompileCache {
       this.compilerInformation.version = this.initializeCompiler();
     }
 
-    let cachePath = this.getCachePath(sourceCode);
-    let js = this.getCachedJavaScript(cachePath);
-
+    let js = null;
+    let cachePath = null;
+    if (!this.disableCache) {
+      cachePath = this.getCachePath(sourceCode);
+      js = this.disableCache ? null : this.getCachedJavaScript(cachePath);
+    } 
+    
     if (!js) {
       js = this.compile(sourceCode, filePath, cachePath);
       this.stats.misses++;
 
-      this.saveCachedJavaScript(cachePath, js);
+      if (!this.disableCache) {
+        this.saveCachedJavaScript(cachePath, js);
+      }
     }
 
     if (returnOnly) return js;
@@ -191,6 +197,7 @@ export default class CompileCache {
   }
 
   setCacheDirectory(newCacheDir) {
+    this.disableCache = (newCacheDir === null);
     if (this.cacheDir === newCacheDir) return;
 
     this.cacheDir = newCacheDir;

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -35,7 +35,7 @@ export default class CompileCache {
   shouldCompileFile(fullPath) {
     this.ensureInitialized();
     let lowerPath = fullPath.toLowerCase();
-
+    
     // If we're in node_modules, we're gonna punt
     if (fullPath.match(/[\\\/]node_modules[\\\/]/i)) return false;
 

--- a/src/for-all-files.js
+++ b/src/for-all-files.js
@@ -1,0 +1,24 @@
+import _ from 'lodash';
+import fs from 'fs';
+import path from 'path';
+
+export default function(rootDirectory, func, ...args) {
+  let rec = (dir) => {
+    _.each(fs.readdirSync(dir), (name) => {
+      let fullName = path.join(dir, name);
+      let stats = fs.statSync(fullName);
+      
+      if (stats.isDirectory()) {
+        rec(fullName);
+        return;
+      }
+      
+      if (stats.isFile()) {
+        func(fullName, ...args);
+        return;
+      }
+    });
+  };
+  
+  rec(rootDirectory);
+}

--- a/src/js/babel.js
+++ b/src/js/babel.js
@@ -38,7 +38,7 @@ export default class BabelCompiler extends CompileCache {
 
   shouldCompileFile(filePath) {
     let ret = super.shouldCompileFile(filePath);
-    if (!ret) return;
+    if (!ret) return false;
     
     // Read the first 4k of the file
     let fd = fs.openSync(filePath, 'r');

--- a/src/main.js
+++ b/src/main.js
@@ -17,10 +17,16 @@ export const availableCompilers = _.map([
   return new Klass();
 });
 
-export function compile(filePath) {
+export function compile(filePath, compilers=null) {
+  if (!hasInitialized && !compilers) {
+    throw new Error("Call init first!");
+  }
+  
+  compilers = compilers || availableCompilers;
+  
   let compiler = null;
-  compiler = _.find(availableCompilers, (x) => x.shouldCompileFile(filePath));
-  if (!compiler) return fs.readFileSync(path, 'utf8');
+  compiler = _.find(compilers, (x) => x.shouldCompileFile(filePath));
+  if (!compiler) return fs.readFileSync(filePath, 'utf8');
 
   let sourceCode = fs.readFileSync(filePath, 'utf8');
   return compiler.loadFile(null, filePath, true, sourceCode);

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,11 @@ import path from 'path';
 import {initializeProtocolHook} from './protocol-hook';
 import forAllFiles from './for-all-files';
 
+// Public: Allows you to create new instances of all compilers that are 
+// supported by electron-compile and use them directly. Currently supports
+// Babel, CoffeeScript, TypeScript, LESS, and Sass/SCSS.
+//
+// Returns an {Array} of {CompileCache} objects.
 export function createAllCompilers() {
   return _.map([
     './js/babel',
@@ -21,10 +26,19 @@ export function createAllCompilers() {
 let availableCompilers = null;
 let lastCacheDir = null;
 
+// Public: Compiles a single file given its path.
+//
+// filePath: The path on disk to the file
+// compilers: (optional) - An {Array} of objects conforming to {CompileCache}
+//                         that will be tried in-order to compile code. You must
+//                         call init() first if this parameter is null.
+//
+// Returns a {String} with the compiled output, or will throw an {Error} 
+// representing the compiler errors encountered.
 export function compile(filePath, compilers=null) {
   compilers = compilers || availableCompilers;
   if (!compilers) {
-    throw new Error("Call init first or pass in an array for compilers");
+    throw new Error("Call init() first or pass in an Array to the compilers parameter");
   }
   
   let compiler = null;
@@ -35,10 +49,32 @@ export function compile(filePath, compilers=null) {
   return compiler.loadFile(null, filePath, true, sourceCode);
 }
 
+// Public: Recursively compiles an entire directory of files.
+//
+// rootDirectory: The path on disk to the directory of files to compile.
+// compilers: (optional) - An {Array} of objects conforming to {CompileCache}
+//                         that will be tried in-order to compile code.
+//
+// Returns nothing.
 export function compileAll(rootDirectory, compilers=null) {
   forAllFiles(rootDirectory, (f) => compile(f, compilers));
 }
 
+// Public: Initializes the electron-compile library. Once this method is called,
+//         all JavaScript and CSS that is loaded will now be first transpiled, in
+//         both the browser and renderer processes. 
+//
+//         Note that because of limitations in Electron, this does **not** apply 
+//         to WebView or Browser preload scripts - call init again at the top of
+//         these scripts to set everything up again.
+//
+// cacheDir: The directory to cache compiled JS and CSS to. If not given, one 
+//           will be generated from the Temp directory.
+//
+// skipRegister: Do not register with the node.js module system - this is used 
+// mostly for unit test purposes.
+//
+// Returns nothing.
 export function init(cacheDir=null, skipRegister=false) {
   if (lastCacheDir === cacheDir && availableCompilers) return;
   

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import fs from 'fs';
 import mkdirp from 'mkdirp';
 import path from 'path';
-import {initializeProtocolHook} from './protocol-hook';
+import initializeProtocolHook from './protocol-hook';
 import forAllFiles from './for-all-files';
 
 // Public: Allows you to create new instances of all compilers that are 

--- a/src/main.js
+++ b/src/main.js
@@ -56,5 +56,5 @@ export function init(cacheDir=null, skipRegister=false) {
 
   // If we're not an Electron browser process, bail
   if (!process.type || process.type !== 'browser') return;
-  initializeProtocolHook(availableCompilers);
+  initializeProtocolHook(availableCompilers, cacheDir);
 }

--- a/src/main.js
+++ b/src/main.js
@@ -5,8 +5,6 @@ import path from 'path';
 import {initializeProtocolHook} from './protocol-hook';
 import forAllFiles from './for-all-files';
 
-let availableCompilers = null;
-
 export function createAllCompilers() {
   return _.map([
     './js/babel',
@@ -19,6 +17,9 @@ export function createAllCompilers() {
     return new Klass();
   });
 }
+
+let availableCompilers = null;
+let lastCacheDir = null;
 
 export function compile(filePath, compilers=null) {
   compilers = compilers || availableCompilers;
@@ -39,6 +40,8 @@ export function compileAll(rootDirectory, compilers=null) {
 }
 
 export function init(cacheDir=null, skipRegister=false) {
+  if (lastCacheDir === cacheDir && availableCompilers) return;
+  
   if (!cacheDir) {
     let tmpDir = process.env.TEMP || process.env.TMPDIR || '/tmp';
     let hash = require('crypto').createHash('md5').update(process.execPath).digest('hex');
@@ -48,6 +51,7 @@ export function init(cacheDir=null, skipRegister=false) {
   }
   
   availableCompilers = createAllCompilers();
+  lastCacheDir = cacheDir;
 
   _.each(availableCompilers, (compiler) => {
     if (!skipRegister) compiler.register();

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import fs from 'fs';
 import mkdirp from 'mkdirp';
 import path from 'path';
 import {initializeProtocolHook} from './protocol-hook';
@@ -15,6 +16,15 @@ export const availableCompilers = _.map([
   const Klass = require(x);
   return new Klass();
 });
+
+export function compile(filePath) {
+  let compiler = null;
+  compiler = _.find(availableCompilers, (x) => x.shouldCompileFile(filePath));
+  if (!compiler) return fs.readFileSync(path, 'utf8');
+
+  let sourceCode = fs.readFileSync(filePath, 'utf8');
+  return compiler.loadFile(null, filePath, true, sourceCode);
+}
 
 export function init(cacheDir=null) {
   if (!cacheDir) {

--- a/src/main.js
+++ b/src/main.js
@@ -34,6 +34,10 @@ export function compile(filePath, compilers=null) {
   return compiler.loadFile(null, filePath, true, sourceCode);
 }
 
+export function compileAll(rootDirectory, compilers=null) {
+  forAllFiles(rootDirectory, (f) => compile(f, compilers));
+}
+
 export function init(cacheDir=null, skipRegister=false) {
   if (!cacheDir) {
     let tmpDir = process.env.TEMP || process.env.TMPDIR || '/tmp';

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,7 @@ import path from 'path';
 import fs from 'fs';
 import url from 'url';
 
-const availableCompilers = _.map([
+export const availableCompilers = _.map([
   './js/babel',
   './js/coffeescript',
   './js/typescript',

--- a/src/main.js
+++ b/src/main.js
@@ -26,7 +26,7 @@ export function compile(filePath) {
   return compiler.loadFile(null, filePath, true, sourceCode);
 }
 
-export function init(cacheDir=null) {
+export function init(cacheDir=null, skipRegister=false) {
   if (!cacheDir) {
     let tmpDir = process.env.TEMP || process.env.TMPDIR || '/tmp';
     let hash = require('crypto').createHash('md5').update(process.execPath).digest('hex');
@@ -36,7 +36,7 @@ export function init(cacheDir=null) {
   }
 
   _.each(availableCompilers, (compiler) => {
-    compiler.register();
+    if (!skipRegister) compiler.register();
     compiler.setCacheDirectory(cacheDir);
   });
   

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,9 @@
 import _ from 'lodash';
 import mkdirp from 'mkdirp';
 import path from 'path';
-import fs from 'fs';
-import url from 'url';
+import {initializeProtocolHook} from './protocol-hook';
+
+let hasInitialized = false;
 
 export const availableCompilers = _.map([
   './js/babel',
@@ -16,10 +17,6 @@ export const availableCompilers = _.map([
 });
 
 export function init(cacheDir=null) {
-  if (process.type && process.type !== 'browser') {
-    throw new Error("Only call this method in the browser process, in app.ready");
-  }
-
   if (!cacheDir) {
     let tmpDir = process.env.TEMP || process.env.TMPDIR || '/tmp';
     let hash = require('crypto').createHash('md5').update(process.execPath).digest('hex');
@@ -32,72 +29,10 @@ export function init(cacheDir=null) {
     compiler.register();
     compiler.setCacheDirectory(cacheDir);
   });
-
-  // If we're node.js / io.js, just bail
-  if (!process.type) return;
-
-  const protocol = require('protocol');
-  protocol.registerProtocol('file', (request) => {
-    let uri = url.parse(request.url);
-
-    // This is a protocol-relative URL that has gone pear-shaped in Electron,
-    // let's rewrite it
-    if (uri.host && uri.host.length > 1) {
-      if (!protocol.RequestHttpJob) {
-        console.log("Tried to correct protocol-relative URL, but this requires Electron 0.28.2 or higher: " + request.url);
-        return new protocol.RequestErrorJob(404);
-      }
-
-      return new protocol.RequestHttpJob({
-        url: request.url.replace(/^file:/, "https:")
-      });
-    }
-
-    let filePath = uri.pathname;
-
-    // NB: pathname has a leading '/' on Win32 for some reason
-    if (process.platform === 'win32') {
-      filePath = filePath.slice(1);
-    }
   
-    let compiler = null;
-    try {
-      compiler = _.find(availableCompilers, (x) => x.shouldCompileFile(filePath));
+  hasInitialized = true;
 
-      if (!compiler) {
-        return new protocol.RequestFileJob(filePath);
-      }
-    } catch (e) {
-      console.log(`Failed to find compiler: ${e.message}\n${e.stack}`);
-      return new protocol.RequestErrorJob(-2); // net::FAILED
-    }
-
-    let sourceCode = null;
-    try {
-      sourceCode = fs.readFileSync(filePath, 'utf8');
-    } catch (e) {
-      // TODO: Actually come correct with these error codes
-      if (e.errno === 34) {
-        return new protocol.RequestErrorJob(6); // net::ERR_FILE_NOT_FOUND
-      }
-
-      console.log(`Failed to read file: ${e.message}\n${e.stack}`);
-      return new protocol.RequestErrorJob(2); // net::FAILED
-    }
-
-    let realSourceCode = null;
-    try {
-      realSourceCode = compiler.loadFile(null, filePath, true, sourceCode);
-    } catch (e) {
-      return new protocol.RequestStringJob({
-        mimeType: compiler.getMimeType(),
-        data: `Failed to compile ${filePath}: ${e.message}\n${e.stack}`
-      });
-    }
-
-    return new protocol.RequestStringJob({
-      mimeType: compiler.getMimeType(),
-      data: realSourceCode,
-    });
-  });
+  // If we're not an Electron browser process, bail
+  if (!process.type || process.type !== 'browser') return;
+  initializeProtocolHook(availableCompilers);
 }

--- a/src/protocol-hook.js
+++ b/src/protocol-hook.js
@@ -1,9 +1,12 @@
 import _ from 'lodash';
-import protocol from 'protocol';
 import url from 'url';  
 import fs from 'fs';
 
+let protocol = null;
+
 export function initializeProtocolHook(availableCompilers) {
+  protocol = protocol || require('protocol');
+  
   protocol.registerProtocol('file', (request) => {
     let uri = url.parse(request.url);
 

--- a/src/protocol-hook.js
+++ b/src/protocol-hook.js
@@ -1,0 +1,70 @@
+import _ from 'lodash';
+import protocol from 'protocol';
+import url from 'url';  
+import fs from 'fs';
+
+export function initializeProtocolHook(availableCompilers) {
+  protocol.registerProtocol('file', (request) => {
+    let uri = url.parse(request.url);
+
+    // This is a protocol-relative URL that has gone pear-shaped in Electron,
+    // let's rewrite it
+    if (uri.host && uri.host.length > 1) {
+      if (!protocol.RequestHttpJob) {
+        console.log("Tried to correct protocol-relative URL, but this requires Electron 0.28.2 or higher: " + request.url);
+        return new protocol.RequestErrorJob(404);
+      }
+
+      return new protocol.RequestHttpJob({
+        url: request.url.replace(/^file:/, "https:")
+      });
+    }
+
+    let filePath = uri.pathname;
+
+    // NB: pathname has a leading '/' on Win32 for some reason
+    if (process.platform === 'win32') {
+      filePath = filePath.slice(1);
+    }
+  
+    let compiler = null;
+    try {
+      compiler = _.find(availableCompilers, (x) => x.shouldCompileFile(filePath));
+
+      if (!compiler) {
+        return new protocol.RequestFileJob(filePath);
+      }
+    } catch (e) {
+      console.log(`Failed to find compiler: ${e.message}\n${e.stack}`);
+      return new protocol.RequestErrorJob(-2); // net::FAILED
+    }
+
+    let sourceCode = null;
+    try {
+      sourceCode = fs.readFileSync(filePath, 'utf8');
+    } catch (e) {
+      // TODO: Actually come correct with these error codes
+      if (e.errno === 34) {
+        return new protocol.RequestErrorJob(6); // net::ERR_FILE_NOT_FOUND
+      }
+
+      console.log(`Failed to read file: ${e.message}\n${e.stack}`);
+      return new protocol.RequestErrorJob(2); // net::FAILED
+    }
+
+    let realSourceCode = null;
+    try {
+      realSourceCode = compiler.loadFile(null, filePath, true, sourceCode);
+    } catch (e) {
+      return new protocol.RequestStringJob({
+        mimeType: compiler.getMimeType(),
+        data: `Failed to compile ${filePath}: ${e.message}\n${e.stack}`
+      });
+    }
+
+    return new protocol.RequestStringJob({
+      mimeType: compiler.getMimeType(),
+      data: realSourceCode,
+    });
+  });
+}

--- a/src/protocol-hook.js
+++ b/src/protocol-hook.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import url from 'url';  
 import fs from 'fs';
 
-const magicWords = "__magic__file__dont__use__this.js";
+const magicWords = "__magic__file__to__help__electron__compile.js";
 
 let protocol = null;
 

--- a/src/protocol-hook.js
+++ b/src/protocol-hook.js
@@ -20,11 +20,11 @@ export function rigHtmlDocumentToInitializeElectronCompile(doc) {
   }
   
   if (!replacedHead) {
-    replacement = `<html><head><script src="${magicWords}"></script></head>`;
+    replacement = `<html$1><head><script src="${magicWords}"></script></head>`;
     for (let i=0; i < lines.length; i++) {
-      if (!lines[i].match(/<html>/i)) continue;
+      if (!lines[i].match(/<html/i)) continue;
       
-      lines[i] = (lines[i]).replace(/<html>/i, replacement);
+      lines[i] = (lines[i]).replace(/<html([^>]+)>/i, replacement);
       break;
     }
   }
@@ -71,6 +71,7 @@ export default function initializeProtocolHook(availableCompilers, cacheDir) {
       
       if (filePath.match(/\.html?$/i)) {
         let contents = fs.readFileSync(filePath, 'utf8');
+
         return new protocol.RequestStringJob({
           mimeType: "text/html",
           data: rigHtmlDocumentToInitializeElectronCompile(contents, cacheDir)

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -1,5 +1,4 @@
 {
-  "es5": true,
   "esnext": true,
   "eqeqeq": true,
   "eqnull": true,

--- a/test/fixtures/protourlrigging_1.html
+++ b/test/fixtures/protourlrigging_1.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html style="width: 100%; height: 100%;">
+  <head>
+    <title></title>
+    <meta http-equiv="Content-Security-Policy" content="default-src *; script-src 'unsafe-eval' 'self' https://www.google-analytics.com; style-src 'self' 'unsafe-inline';">
+
+    <link rel="import" href="./notification-host.html" />
+    <link rel="import" href="./notification-item.html" />
+    <link rel="import" href="./loading.html" />
+    <link rel="import" href="./login.html" />
+    <link rel="import" href="./teams-view.html" />
+    <link rel="import" href="./team-selector.html" />
+    <link rel="import" href="./team-selector-item.html" />
+
+    <script src="bugsnag-2.js"></script>
+    <script src="index.js"></script>
+
+    <script src="analytics.js"></script>
+    <script async src='https://www.google-analytics.com/analytics.js'></script>
+  </head>
+
+  <body tabindex="-1">
+  </body>
+</html>

--- a/test/fixtures/protourlrigging_2.html
+++ b/test/fixtures/protourlrigging_2.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html style="width: 100%; height: 100%;">
+  <body tabindex="-1">
+    <h2>Hello World!</h2>
+  </body>
+</html>

--- a/test/main.js
+++ b/test/main.js
@@ -1,13 +1,13 @@
 require('./support.js');
 
 import _ from 'lodash';
-import {compile, compileAll, createAllCompilers} from '../lib/main';
 import path from 'path';
-import rimraf from 'rimraf'
+import rimraf from 'rimraf';
 
 import TypeScriptCompiler from '../lib/js/typescript';
 import LessCompiler from '../lib/css/less';
 import forAllFiles from '../lib/for-all-files';
+import {compile, compileAll, createAllCompilers} from '../lib/main';
 
 describe('exports for this library', function() {
   describe('the compile method', function() {

--- a/test/main.js
+++ b/test/main.js
@@ -1,10 +1,13 @@
 require('./support.js');
 
 import _ from 'lodash';
-import {compile} from '../lib/main';
+import {compile, compileAll, createAllCompilers} from '../lib/main';
 import path from 'path';
+import rimraf from 'rimraf'
+
 import TypeScriptCompiler from '../lib/js/typescript';
 import LessCompiler from '../lib/css/less';
+import forAllFiles from '../lib/for-all-files';
 
 describe('exports for this library', function() {
   describe('the compile method', function() {
@@ -37,6 +40,34 @@ describe('exports for this library', function() {
       }
       
       expect(shouldDie).not.to.be.ok;
+    });
+  });
+  
+  describe('the compileAll method', function() {
+    it('should create a cache directory for our sources folder', function() {
+      let source = path.join(__dirname, '..', 'src');
+      let targetDir = path.join(__dirname, 'compileAllCacheTest');
+      
+      try {
+        let compilers = createAllCompilers();
+        _.each(compilers, (x) => x.setCacheDirectory(targetDir));
+        
+        expect(compilers).to.be.ok;
+        
+        compileAll(source, compilers);
+        
+        let sourceFileCount = 0;
+        forAllFiles(source, () => sourceFileCount++);
+        
+        let targetFileCount = 0;
+        forAllFiles(targetDir, () => targetFileCount++);
+        
+        //console.log(`compileAll: ${sourceFileCount} files in source, ${targetFileCount} in target`);
+        expect(sourceFileCount === targetFileCount).to.be.ok;
+        expect(sourceFileCount !== 0).to.be.ok;
+      } finally {
+        rimraf.sync(targetDir);
+      }
     });
   });
 });

--- a/test/main.js
+++ b/test/main.js
@@ -69,5 +69,27 @@ describe('exports for this library', function() {
         rimraf.sync(targetDir);
       }
     });
+    
+    it('should fail when files have errors', function() {
+      let source = path.join(__dirname, '..', 'test', 'fixtures');
+      let targetDir = path.join(__dirname, 'compileAllFailCacheTest');
+      
+      let shouldDie = true;
+      try {
+        let compilers = createAllCompilers();
+        _.each(compilers, (x) => x.setCacheDirectory(targetDir));
+        
+        expect(compilers).to.be.ok;
+        
+        compileAll(source, compilers);
+      } catch (e) {
+        shouldDie = false;
+      } finally {
+        rimraf.sync(targetDir);
+      }
+      
+      expect(shouldDie).not.to.be.ok;
+    });
   });
 });
+  

--- a/test/main.js
+++ b/test/main.js
@@ -1,0 +1,29 @@
+require('./support.js');
+
+import {compile} from '../lib/main';
+import path from 'path';
+
+describe('exports for this library', function() {
+  describe('the compile method', function() {
+    it('should compile a LESS file', function() {
+      let result = compile(path.resolve(__dirname, 'fixtures', 'valid.less'));
+      expect(result.length > 10).to.be.ok;
+    });
+    
+    it('should passthrough files it doesnt recognize', function() {
+      let result = compile(path.resolve(__dirname, '..', '.gitignore'));
+      expect(result.length > 10).to.be.ok;
+    });
+    
+    it('should blow up on bad input', function() {
+      let shouldDie = true;
+      try {
+        compile(path.resolve(__dirname, 'fixtures', 'invalid.ts'));
+      } catch (e) {
+        shouldDie = false;
+      }
+      
+      expect(shouldDie).not.to.be.ok;
+    });
+  });
+});

--- a/test/main.js
+++ b/test/main.js
@@ -1,24 +1,37 @@
 require('./support.js');
 
+import _ from 'lodash';
 import {compile} from '../lib/main';
 import path from 'path';
+import TypeScriptCompiler from '../lib/js/typescript';
+import LessCompiler from '../lib/css/less';
 
 describe('exports for this library', function() {
   describe('the compile method', function() {
+    beforeEach(function() {
+      this.compilers = [
+        new TypeScriptCompiler(),
+        new LessCompiler()
+      ];
+      
+      // Disable caching on compilers
+      _.each(this.compilers, (x) => x.setCacheDirectory(null));
+    });
+    
     it('should compile a LESS file', function() {
-      let result = compile(path.resolve(__dirname, 'fixtures', 'valid.less'));
+      let result = compile(path.resolve(__dirname, '..', 'test', 'fixtures', 'valid.less'), this.compilers);
       expect(result.length > 10).to.be.ok;
     });
     
     it('should passthrough files it doesnt recognize', function() {
-      let result = compile(path.resolve(__dirname, '..', '.gitignore'));
+      let result = compile(path.resolve(__dirname, '..', '.gitignore'), this.compilers);
       expect(result.length > 10).to.be.ok;
     });
     
     it('should blow up on bad input', function() {
       let shouldDie = true;
       try {
-        compile(path.resolve(__dirname, 'fixtures', 'invalid.ts'));
+        compile(path.resolve(__dirname, '..', 'test', 'fixtures', 'invalid.ts'), this.compilers);
       } catch (e) {
         shouldDie = false;
       }

--- a/test/protocol-hook.js
+++ b/test/protocol-hook.js
@@ -1,0 +1,27 @@
+require('./support.js');
+
+import _ from 'lodash';
+import path from 'path';
+import fs from 'fs';
+
+import {rigHtmlDocumentToInitializeElectronCompile} from '../lib/protocol-hook';
+
+describe('protocol hook library', function() {
+  describe('The HTML include rigging', function() {
+    it('should rig pages with HEAD tags', function() {
+      let content = fs.readFileSync(path.join(__dirname, '..', 'test', 'fixtures', 'protourlrigging_1.html'), 'utf8');
+      let result = rigHtmlDocumentToInitializeElectronCompile(content);
+      
+      let lines = result.split('\n');
+      expect(_.any(lines, (x) => x.match(/head.*__magic__file/i))).to.be.ok;
+    });
+    
+    it('should rig pages without tags', function() {
+      let content = fs.readFileSync(path.join(__dirname, '..', 'test', 'fixtures', 'protourlrigging_2.html'), 'utf8');
+      let result = rigHtmlDocumentToInitializeElectronCompile(content);
+      
+      let lines = result.split('\n');
+      expect(_.any(lines, (x) => x.match(/head.*__magic__file/i))).to.be.ok;
+    });
+  });
+});


### PR DESCRIPTION
This PR allows you to pre-build the cache folder ahead of time for every file in your app, via a new `electron-compile` CLI app:

```sh
Usage: electron-compile --target [target-path] paths...

Options:
  -t, --target   The target directory to write a cache directory to
  -v, --verbose  Print verbose information
  -h, --help     Show help
```

This PR also adds new methods exported to the main object for compiling via code:

```js
// Public: Compiles a single file given its path.
//
// filePath: The path on disk to the file
// compilers: (optional) - An {Array} of objects conforming to {CompileCache}
//                         that will be tried in-order to compile code. You must
//                         call init() first if this parameter is null.
//
// Returns a {String} with the compiled output, or will throw an {Error} 
// representing the compiler errors encountered.
export function compile(filePath, compilers=null)

// Public: Recursively compiles an entire directory of files.
//
// rootDirectory: The path on disk to the directory of files to compile.
// compilers: (optional) - An {Array} of objects conforming to {CompileCache}
//                         that will be tried in-order to compile code.
//
// Returns nothing.
export function compileAll(rootDirectory, compilers=null)

// Public: Allows you to create new instances of all compilers that are 
// supported by electron-compile and use them directly. Currently supports
// Babel, CoffeeScript, TypeScript, LESS, and Sass/SCSS.
//
// Returns an {Array} of {CompileCache} objects.
export function createAllCompilers()
```

### One Last Thing

This PR also fixes a semi-related bug where `require` in the renderer process wouldn't get transpiled files.