### PR TITLE
Allow users to set per-compiler options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,25 @@ Add `'use nobabel';` to the top of your file to opt-out of Babel compilation.
 
 Unfortunately, the very first file that you set up electron-compile in must be written in ES5. Of course, you can always make this file exactly two lines, the 'init' statement, then require your real main.js in.
 
-## Precompiling
+### How do I set up (Babel / LESS / whatever) the way I want?
+
+In order to configure individual compilers, use the `initWithOptions` method:
+
+```js
+let babelOpts = {
+  stage: 2
+};
+
+initWithOptions({
+  cacheDir: '/path/to/my/cache',
+  compilerOpts: {
+    // Compiler options are a map of extension <=> options for compiler
+    js: babelOpts
+  }
+});
+```
+
+## How can I precompile my code for release-time?
 
 electron-compile comes with a command-line application to pre-create a cache for you.
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,10 @@ For CSS:
 
 ### How does it work?
 
-Put this in your Electron app's `app.ready`:
+Put this at the top of your Electron app:
 
 ```js
-app.on('ready', function() {
-  require('electron-compile').init();
-});
+require('electron-compile').init();
 ```
 
 From then on, you can now simply include files directly in your HTML, no need for cross-compilation:
@@ -48,7 +46,7 @@ Add `'use nobabel';` to the top of your file to opt-out of Babel compilation.
 
 ### Hey, why doesn't this work in my main.js file?
 
-Unfortunately, the very first file that you set up `app.ready` in must be written in ES5. Of course, you can always make this file as small as possible, or just require in a real file once you call `init()`.
+Unfortunately, the very first file that you set up electron-compile in must be written in ES5. Of course, you can always make this file exactly two lines, the 'init' statement, then require your real main.js in.
 
 ## Precompiling
 
@@ -66,9 +64,7 @@ Options:
 Once you create a cache folder, pass it in as a parameter to `init()`. Ship the cache folder with your application, and you won't need to compile the app on first-run:
 
 ```js
-app.on('ready', function() {
-  require('electron-compile').init('path/to/precompiled/cache/folder');
-});
+require('electron-compile').init('path/to/precompiled/cache/folder');
 ```
 
 Compilation also has its own API:

--- a/src/css/less.js
+++ b/src/css/less.js
@@ -5,6 +5,7 @@ import path from 'path';
 import CompileCache from '../compile-cache';
 
 let lessjs = null;
+const extensions = ['less'];
 
 export default class LessCompiler extends CompileCache {
   constructor(options={}) {
@@ -16,7 +17,7 @@ export default class LessCompiler extends CompileCache {
     };
 
     const requiredOptions = {
-      extension: 'less',
+      extensions: extensions,
       fileAsync: false, async: false, syncImport: true
     };
 

--- a/src/css/less.js
+++ b/src/css/less.js
@@ -22,6 +22,10 @@ export default class LessCompiler extends CompileCache {
 
     this.compilerInformation = _.extend(defaultOptions, options, requiredOptions);
   }
+  
+  static getExtensions() {
+    return extensions;
+  }
 
   getCompilerInformation() {
     return this.compilerInformation;

--- a/src/css/scss.js
+++ b/src/css/scss.js
@@ -5,6 +5,7 @@ import CompileCache from '../compile-cache';
 let scss = null;
 
 const scssFileExtensions = /\.(sass|scss)$/i;
+const extensions = ['scss', 'sass'];
 
 export default class ScssCompiler extends CompileCache {
   constructor(options={}) {
@@ -17,10 +18,14 @@ export default class ScssCompiler extends CompileCache {
     };
 
     const requiredOptions = {
-      extensions: ['scss', 'sass']
+      extensions: extensions
     };
 
     this.compilerInformation = _.extend(defaultOptions, options, requiredOptions);
+  }
+  
+  static getExtensions() {
+    return extensions;
   }
 
   getCompilerInformation() {

--- a/src/js/babel.js
+++ b/src/js/babel.js
@@ -5,13 +5,14 @@ import fs from 'fs';
 let babel = require('babel-core');
 
 const validOpts = ['sourceMap', 'blacklist', 'stage', 'optional'];
+const extensions = ['js'];
 
 export default class BabelCompiler extends CompileCache {
   constructor(options={}) {
     super();
 
     this.compilerInformation = _.extend({}, {
-      extension: 'js',
+      extensions: extensions,
       sourceMap: 'inline',
       blacklist: [
         'useStrict'
@@ -23,6 +24,10 @@ export default class BabelCompiler extends CompileCache {
         'asyncToGenerator'
       ],
     }, options);
+  }
+  
+  static getExtensions() {
+    return extensions;
   }
 
   getCompilerInformation() {

--- a/src/js/babel.js
+++ b/src/js/babel.js
@@ -4,8 +4,8 @@ import fs from 'fs';
 
 let babel = require('babel-core');
 
-const validOpts = ['sourceMap', 'blacklist', 'stage', 'optional'];
-const extensions = ['js'];
+const invalidOpts = ['extension', 'extensions', 'version'];
+const extensions = ['js', 'jsx'];
 
 export default class BabelCompiler extends CompileCache {
   constructor(options={}) {
@@ -13,7 +13,7 @@ export default class BabelCompiler extends CompileCache {
 
     this.compilerInformation = _.extend({}, {
       extensions: extensions,
-      sourceMap: 'inline',
+      sourceMaps: 'inline',
       blacklist: [
         'useStrict'
       ],
@@ -35,7 +35,7 @@ export default class BabelCompiler extends CompileCache {
   }
 
   compile(sourceCode) {
-    this.babelCompilerOpts = this.babelCompilerOpts || _.pick(this.compilerInformation, validOpts);
+    this.babelCompilerOpts = this.babelCompilerOpts || _.omit(this.compilerInformation, invalidOpts);
     return babel.transform(sourceCode, this.babelCompilerOpts).code;
   }
 

--- a/src/js/coffeescript.js
+++ b/src/js/coffeescript.js
@@ -5,20 +5,25 @@ import btoa from 'btoa';
 import CompileCache from '../compile-cache';
 
 let coffee = null;
+const extensions = ['coffee'];
 
 export default class CoffeeScriptCompiler extends CompileCache {
   constructor(options={}) {
     super();
 
     this.compilerInformation = _.extend({}, {
-      extension: 'coffee',
+      extensions: extensions,
     }, options);
+  }
+  
+  static getExtensions() {
+    return extensions;
   }
 
   getCompilerInformation() {
     return this.compilerInformation;
   }
-
+  
   compile(sourceCode, filePath) {
     let {js, v3SourceMap} = coffee.compile(sourceCode, { filename: filePath, sourceMap: true });
 

--- a/src/js/typescript.js
+++ b/src/js/typescript.js
@@ -2,17 +2,22 @@ import _ from 'lodash';
 import CompileCache from '../compile-cache';
 
 let tss = null;
+const extensions = ['ts'];
 
 export default class TypeScriptCompiler extends CompileCache {
   constructor(options={}) {
     super();
 
     this.compilerInformation = _.extend({}, {
-      extension: 'ts',
+      extensions: extensions,
       target: 1,
       module: 'commonjs',
       sourceMap: true
     }, options);
+  }
+  
+  static getExtensions() {
+    return extensions;
   }
 
   getCompilerInformation() {

--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,7 @@ import forAllFiles from './for-all-files';
 // Babel, CoffeeScript, TypeScript, LESS, and Sass/SCSS.
 //
 // Returns an {Array} of {CompileCache} objects.
-export function createAllCompilers() {
+export function createAllCompilers(compilerOpts={}) {
   return _.map([
     './js/babel',
     './js/coffeescript',

--- a/src/main.js
+++ b/src/main.js
@@ -140,5 +140,13 @@ export function initWithOptions(options={}) {
 
   // If we're not an Electron browser process, bail
   if (!process.type || process.type !== 'browser') return;
-  initializeProtocolHook(availableCompilers, cacheDir);
+  
+  const app = require('app');
+  const initProtoHook = () => initializeProtocolHook(availableCompilers, cacheDir);
+  
+  if (app.isReady()) {
+    initProtoHook();
+  } else {
+    app.on('ready', initProtoHook);
+  }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -60,6 +60,7 @@ export function compileAll(rootDirectory, compilers=null) {
   forAllFiles(rootDirectory, (f) => compile(f, compilers));
 }
 
+
 // Public: Initializes the electron-compile library. Once this method is called,
 //         all JavaScript and CSS that is loaded will now be first transpiled, in
 //         both the browser and renderer processes. 
@@ -76,6 +77,14 @@ export function compileAll(rootDirectory, compilers=null) {
 //
 // Returns nothing.
 export function init(cacheDir=null, skipRegister=false) {
+  this.initWithOptions({
+    cacheDir: cacheDir,
+    skipRegister: skipRegister
+  });
+}
+
+export function initWithOptions(options={}) {
+  let {cacheDir, skipRegister, compilers} = options;
   if (lastCacheDir === cacheDir && availableCompilers) return;
   
   if (!cacheDir) {
@@ -86,7 +95,7 @@ export function init(cacheDir=null, skipRegister=false) {
     mkdirp.sync(cacheDir);
   }
   
-  availableCompilers = createAllCompilers();
+  availableCompilers = compilers || createAllCompilers();
   lastCacheDir = cacheDir;
 
   _.each(availableCompilers, (compiler) => {

--- a/src/main.js
+++ b/src/main.js
@@ -91,6 +91,33 @@ export function init(cacheDir=null, skipRegister=false) {
   });
 }
 
+// Public: Initializes the electron-compile library. Once this method is called,
+//         all JavaScript and CSS that is loaded will now be first transpiled, in
+//         both the browser and renderer processes. 
+//
+//         Note that because of limitations in Electron, this does **not** apply 
+//         to WebView or Browser preload scripts - call init again at the top of
+//         these scripts to set everything up again.
+//
+//  options: an options {Object} with the following keys:
+//
+//     :cacheDir - The directory to cache compiled JS and CSS to. If not given, 
+//                 one will be generated from the Temp directory.
+//
+//     :skipRegister - Do not register with the node.js module system. For testing.
+//
+//     :compilers - An {Array} of compilers conforming to {CompileCache}, usually
+//                  created via {createAllCompilers}.
+//
+//     :compilerOpts - An {Object} which will be used to initialize compilers - the
+//                     keys are the extension without a dot (i.e. 'js'), and the
+//                     values are the options object that this compiler would take.
+//
+//                     For example: {'js': { comments: false }} will disable comments
+//                     in Babel's generated output. See the compiler's associated docs
+//                     for what can be passed in as options.
+//
+// Returns nothing.
 export function initWithOptions(options={}) {
   let {cacheDir, skipRegister, compilers} = options;
   if (lastCacheDir === cacheDir && availableCompilers) return;

--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,7 @@ import forAllFiles from './for-all-files';
 // Babel, CoffeeScript, TypeScript, LESS, and Sass/SCSS.
 //
 // Returns an {Array} of {CompileCache} objects.
-export function createAllCompilers(compilerOpts={}) {
+export function createAllCompilers(compilerOpts=null) {
   return _.map([
     './js/babel',
     './js/coffeescript',
@@ -19,7 +19,15 @@ export function createAllCompilers(compilerOpts={}) {
     './css/scss'
   ], (x) => {
     const Klass = require(x);
-    return new Klass();
+    if (!compilerOpts) return new Klass();
+    
+    let exts = Klass.getExtensions();
+    let optsForUs = _.reduce(
+      exts, 
+      (acc,x) => _.extend(acc, compilerOpts[x] || {}),
+      {});
+      
+    return new Klass(optsForUs);
   });
 }
 
@@ -95,7 +103,7 @@ export function initWithOptions(options={}) {
     mkdirp.sync(cacheDir);
   }
   
-  availableCompilers = compilers || createAllCompilers();
+  availableCompilers = compilers || createAllCompilers(options.compilerOpts);
   lastCacheDir = cacheDir;
 
   _.each(availableCompilers, (compiler) => {

--- a/test/main.js
+++ b/test/main.js
@@ -91,5 +91,41 @@ describe('exports for this library', function() {
       expect(shouldDie).not.to.be.ok;
     });
   });
+  
+  describe('The createAllCompilers method', function() {
+    it('should create a bunch of compilers', function() {
+      let result = createAllCompilers();
+      _.each(result, (x) => x.setCacheDirectory(null));
+      
+      let extensions = _.map(result, (x) => x.getCompilerInformation().extensions);
+      
+      expect(_.find(extensions, (x) => x[0] === 'js')).to.be.ok;
+      expect(_.find(extensions, (x) => x[0] === 'less')).to.be.ok;
+    });
+    
+    it('should accept compile options', function() {
+      // First with comments on
+      let opts = {
+        js: { comments: true, sourceMaps: false }
+      };
+      
+      let result = createAllCompilers(opts);
+      _.each(result, (x) => x.setCacheDirectory(null));
+      
+      let output = compile(path.resolve(__dirname, '..', 'test', 'fixtures', 'valid.js'), result);
+      expect(_.find(output.split("\n"), (x) => x.match(/\/\//))).to.be.ok;
+      
+      // Run it again with comments off
+      opts = {
+        js: { comments: false, sourceMaps: false }
+      };
+      
+      result = createAllCompilers(opts);
+      _.each(result, (x) => x.setCacheDirectory(null));
+      
+      output = compile(path.resolve(__dirname, '..', 'test', 'fixtures', 'valid.js'), result);
+      expect(_.find(output.split("\n"), (x) => x.match(/\/\//))).not.to.be.ok;
+    });
+  });
 });
   


### PR DESCRIPTION
This PR adds a new initWithOptions method that allows callers to configure settings passed into each compiler.

```js
// Public: Initializes the electron-compile library. Once this method is called,
//         all JavaScript and CSS that is loaded will now be first transpiled, in
//         both the browser and renderer processes. 
//
//         Note that because of limitations in Electron, this does **not** apply 
//         to WebView or Browser preload scripts - call init again at the top of
//         these scripts to set everything up again.
//
//  options: an options {Object} with the following keys:
//
//     :cacheDir - The directory to cache compiled JS and CSS to. If not given, 
//                 one will be generated from the Temp directory.
//
//     :skipRegister - Do not register with the node.js module system. For testing.
//
//     :compilers - An {Array} of compilers conforming to {CompileCache}, usually
//                  created via {createAllCompilers}.
//
//     :compilerOpts - An {Object} which will be used to initialize compilers - the
//                     keys are the extension without a dot (i.e. 'js'), and the
//                     values are the options object that this compiler would take.
//
//                     For example: {'js': { comments: false }} will disable comments
//                     in Babel's generated output. See the compiler's associated docs
//                     for what can be passed in as options.
//
// Returns nothing.
export function initWithOptions(options={})
```

Example invocation:

```js
initWithOptions({
  cacheDir: '/path/to/my/cache',
  compilerOpts: {
    js: { stage: 2 }
  }
});
```