### PR TITLE
Inline compilation of Script and Style tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "btoa": "^1.1.2",
     "electron-compile-cache": "^0.6.2",
-    "electron-compilers": "^0.6.2",
+    "electron-compilers": "^0.7.0",
     "lodash": "^3.8.0",
     "mkdirp": "^0.5.0",
     "yargs": "^3.8.0"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "chai": "^2.3.0",
     "chai-as-promised": "^5.0.0",
     "chai-spies": "^0.6.0",
+    "cheerio": "^0.19.0",
     "mocha": "^2.2.4",
     "rimraf": "^2.4.1"
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/paulcbetts/electron-compile",
   "dependencies": {
     "btoa": "^1.1.2",
-    "electron-compile-cache": "^0.6.0",
+    "electron-compile-cache": "^0.6.2",
     "electron-compilers": "^0.6.2",
     "lodash": "^3.8.0",
     "mkdirp": "^0.5.0",

--- a/src/protocol-hook.js
+++ b/src/protocol-hook.js
@@ -82,17 +82,15 @@ export default function initializeProtocolHook(availableCompilers, initializeOpt
         return new protocol.RequestFileJob(filePath);
     }
   
+    let sourceCode = null;
     let compiler = null;
+    
     try {
       compiler = _.find(availableCompilers, (x) => x.shouldCompileFile(filePath));
       
       if (!disableAutoRendererSetup && filePath.match(/\.html?$/i)) {
         let contents = fs.readFileSync(filePath, 'utf8');
-
-        return new protocol.RequestStringJob({
-          mimeType: "text/html",
-          data: rigHtmlDocumentToInitializeElectronCompile(contents, initializeOpts.cacheDir)
-        });
+        sourceCode = rigHtmlDocumentToInitializeElectronCompile(contents, initializeOpts.cacheDir);
       }
       
       if (!compiler) {
@@ -103,9 +101,8 @@ export default function initializeProtocolHook(availableCompilers, initializeOpt
       return new protocol.RequestErrorJob(-2); // net::FAILED
     }
 
-    let sourceCode = null;
     try {
-      sourceCode = fs.readFileSync(filePath, 'utf8');
+      sourceCode = sourceCode || fs.readFileSync(filePath, 'utf8');
     } catch (e) {
       // TODO: Actually come correct with these error codes
       if (e.errno === 34) {

--- a/test/compile-cache.js
+++ b/test/compile-cache.js
@@ -2,6 +2,7 @@ require('./support.js');
 
 import path from 'path';
 import rimraf from 'rimraf';
+import fs from 'fs';
 
 const BabelCompiler = global.importCompilerByExtension('js');
 const TypeScriptCompiler = global.importCompilerByExtension('ts');
@@ -24,6 +25,31 @@ describe('The compile cache', function() {
       
       // Calling loadFile > 1x with same content == no compiling
       result = fixture.loadFile(module, input, true);
+      expect(result.length > 0).to.be.ok;
+      expect(fixture.compile).to.have.been.called.once;
+    } finally {
+      rimraf.sync(cacheDir);
+    }
+  });
+  
+  it('should work even when filePath isnt a real file', function() {
+    let fixture = new BabelCompiler();
+    
+    spy.on(fixture, 'compile');
+    
+    let cacheDir = path.join(__dirname, 'cache-test-2');
+    fixture.setCacheDirectory(cacheDir);
+    
+    try {
+      let input = path.join(__dirname, '..', 'test', 'fixtures', 'valid.js');
+      let code = fs.readFileSync(input, 'utf8');
+      let result = fixture.loadFile(null, input + ":inline.js", true, code);
+      
+      expect(result.length > 0).to.be.ok;
+      expect(fixture.compile).to.have.been.called.once;
+      
+      // Calling loadFile > 1x with same content == no compiling
+      result = fixture.loadFile(null, input + ":inline.js", true, code);
       expect(result.length > 0).to.be.ok;
       expect(fixture.compile).to.have.been.called.once;
     } finally {

--- a/test/fixtures/inline-valid-2.html
+++ b/test/fixtures/inline-valid-2.html
@@ -1,0 +1,164 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../paper-styles/typography.html">
+<link rel="import" href="../iron-a11y-announcer/iron-a11y-announcer.html">
+
+<!--
+`paper-toast` provides a subtle notification toast.
+
+@group Paper Elements
+@element paper-toast
+@demo demo/index.html
+@hero hero.svg
+-->
+<dom-module id="paper-toast">
+  <style>
+    :host {
+      display: inline-block;
+      position: fixed;
+
+      background: #323232;
+      color: #f1f1f1;
+      min-height: 48px;
+      min-width: 288px;
+      padding: 16px 24px 12px;
+      box-sizing: border-box;
+      box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);
+      border-radius: 2px;
+      bottom: 12px;
+      left: 12px;
+      font-size: 14px;
+      cursor: default;
+
+      -webkit-transition: visibility 0.3s, -webkit-transform 0.3s;
+      transition: visibility 0.3s, transform 0.3s;
+
+      -webkit-transform: translateY(100px);
+      transform: translateY(100px);
+
+      visibility: hidden;
+    }
+
+    :host(.capsule) {
+      border-radius: 24px;
+    }
+
+    :host(.fit-bottom) {
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      min-width: 0;
+      border-radius: 0;
+    }
+
+    :host(.paper-toast-open){
+      visibility: visible;
+
+      -webkit-transform: translateY(0px);
+      transform: translateY(0px);
+    }
+  </style>
+  <template>
+    <span id="label">{{text}}</span>
+    <content></content>
+  </template>
+</dom-module>
+<script>
+(function() {
+
+  var PaperToast = Polymer({
+    is: 'paper-toast',
+
+    properties: {
+      /**
+       * The duration in milliseconds to show the toast.
+       */
+      duration: {
+        type: Number,
+        value: 3000
+      },
+
+      /**
+       * The text to display in the toast.
+       */
+      text: {
+        type: String,
+        value: ""
+      },
+
+      /**
+       * True if the toast is currently visible.
+       */
+      visible: {
+        type: Boolean,
+        readOnly: true,
+        value: false,
+        observer: '_visibleChanged'
+      }
+    },
+
+    created: function() {
+      Polymer.IronA11yAnnouncer.requestAvailability();
+    },
+
+    ready: function() {
+      this.async(function() {
+        this.hide();
+      });
+    },
+
+    /**
+     * Show the toast.
+     * @method show
+     */
+    show: function() {
+      if (PaperToast.currentToast) {
+        PaperToast.currentToast.hide();
+      }
+      PaperToast.currentToast = this;
+      this.removeAttribute('aria-hidden');
+      this._setVisible(true);
+      this.fire('iron-announce', {
+        text: this.text
+      });
+      this.debounce('hide', this.hide, this.duration);
+    },
+
+    /**
+     * Hide the toast
+     */
+    hide: function() {
+      this.setAttribute('aria-hidden', 'true');
+      this._setVisible(false);
+    },
+
+    /**
+     * Toggle the opened state of the toast.
+     * @method toggle
+     */
+    toggle: function() {
+      if (!this.visible) {
+        this.show();
+      } else {
+        this.hide();
+      }
+    },
+
+    _visibleChanged: function(visible) {
+      this.toggleClass('paper-toast-open', visible);
+    }
+  });
+
+  PaperToast.currentToast = null;
+
+})();
+</script>

--- a/test/fixtures/inline-valid.html
+++ b/test/fixtures/inline-valid.html
@@ -1,0 +1,51 @@
+<dom-module id="loading-screen">
+  <style type="text/less">
+  :host {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+  }
+  </style>
+
+  <template>
+    <iron-pages id="selector" selected="{{_pageForScreen(screen)}}">
+      <div class="page">
+      </div>
+
+      <div class="page">
+      </div>
+
+      <div class="page">
+      </div>
+    </iron-pages>
+  </template>
+
+  <script>
+  global.Polymer({
+    is: 'loading-screen',
+    properties: {
+      screen: {
+        type: String,
+        reflectToAttribute: true
+      }
+    },
+    
+    _emitRetry: () => {
+      this.fire('retry');
+    },
+
+    _pageForScreen: (theScreen) => {
+      return pageMap[theScreen];
+    }
+  });
+  </script>
+
+  <script src="https://lol"></script>
+  
+  <script type="application/coffeescript">
+  f = ->
+    foo();
+  </script>
+</dom-module>

--- a/test/inline-html-compiler.js
+++ b/test/inline-html-compiler.js
@@ -1,0 +1,49 @@
+require('./support.js');
+
+import _ from 'lodash';
+import fs from 'fs';
+import path from 'path';
+import cheerio from 'cheerio';
+
+const LessCompiler = global.importCompilerByExtension('less');
+const BabelCompiler = global.importCompilerByExtension('js');
+const CoffeescriptCompiler = global.importCompilerByExtension('coffee');
+const InlineHtmlCompiler = global.importCompilerByExtension('html');
+
+describe('The inline HTML compiler', function() {
+  it('should compile the valid fixture', function() {
+    let compilers = _.map([LessCompiler, BabelCompiler, CoffeescriptCompiler], (Klass) => {
+      let ret = new Klass();
+      ret.setCacheDirectory(null);
+      return ret;
+    });
+    
+    let fixture = new InlineHtmlCompiler((sourceCode, filePath) => {
+      let compiler = _.find(compilers, (x) => x.shouldCompileFile(filePath, sourceCode));
+      if (!compiler) {
+        throw new Error("Couldn't find a compiler for " + filePath);
+      }
+      
+      return compiler.loadFile(null, filePath, true, sourceCode);
+    });
+    
+    fixture.setCacheDirectory(null);
+    
+    let input = path.join(__dirname, '..', 'test', 'fixtures', 'inline-valid.html');
+    let result = fixture.loadFile(null, input, true);
+        
+    console.log(result);
+    expect(result.length > 0).to.be.ok;
+    
+    let $ = cheerio.load(result);
+    let tags = $('script');
+    expect(tags.length === 3).to.be.ok
+    
+    $('script').map((__, el) => {
+      let text = $(el).text();
+      if (!text || text.length < 2) return;
+      
+      expect(_.find(text.split('\n'), (l) => l.match(/sourceMappingURL/))).to.be.ok;
+    });
+  });
+});

--- a/test/inline-html-compiler.js
+++ b/test/inline-html-compiler.js
@@ -10,40 +10,47 @@ const BabelCompiler = global.importCompilerByExtension('js');
 const CoffeescriptCompiler = global.importCompilerByExtension('coffee');
 const InlineHtmlCompiler = global.importCompilerByExtension('html');
 
+const validInputs = [
+  'inline-valid.html',
+  'inline-valid-2.html',
+]
+
 describe('The inline HTML compiler', function() {
-  it('should compile the valid fixture', function() {
-    let compilers = _.map([LessCompiler, BabelCompiler, CoffeescriptCompiler], (Klass) => {
-      let ret = new Klass();
-      ret.setCacheDirectory(null);
-      return ret;
-    });
-    
-    let fixture = new InlineHtmlCompiler((sourceCode, filePath) => {
-      let compiler = _.find(compilers, (x) => x.shouldCompileFile(filePath, sourceCode));
-      if (!compiler) {
-        throw new Error("Couldn't find a compiler for " + filePath);
-      }
+  
+  _.each(validInputs, (inputFile) => {
+    it('should compile the valid fixture ' + inputFile, function() {
+      let compilers = _.map([LessCompiler, BabelCompiler, CoffeescriptCompiler], (Klass) => {
+        let ret = new Klass();
+        ret.setCacheDirectory(null);
+        return ret;
+      });
       
-      return compiler.loadFile(null, filePath, true, sourceCode);
-    });
-    
-    fixture.setCacheDirectory(null);
-    
-    let input = path.join(__dirname, '..', 'test', 'fixtures', 'inline-valid.html');
-    let result = fixture.loadFile(null, input, true);
+      let fixture = new InlineHtmlCompiler((sourceCode, filePath) => {
+        let compiler = _.find(compilers, (x) => x.shouldCompileFile(filePath, sourceCode));
+        if (!compiler) {
+          throw new Error("Couldn't find a compiler for " + filePath);
+        }
         
-    console.log(result);
-    expect(result.length > 0).to.be.ok;
-    
-    let $ = cheerio.load(result);
-    let tags = $('script');
-    expect(tags.length === 3).to.be.ok
-    
-    $('script').map((__, el) => {
-      let text = $(el).text();
-      if (!text || text.length < 2) return;
+        return compiler.loadFile(null, filePath, true, sourceCode);
+      });
       
-      expect(_.find(text.split('\n'), (l) => l.match(/sourceMappingURL/))).to.be.ok;
+      fixture.setCacheDirectory(null);
+      
+      let input = path.join(__dirname, '..', 'test', 'fixtures', inputFile);
+      let result = fixture.loadFile(null, input, true);
+          
+      expect(result.length > 0).to.be.ok;
+      
+      let $ = cheerio.load(result);
+      let tags = $('script');
+      expect(tags.length > 0).to.be.ok
+      
+      $('script').map((__, el) => {
+        let text = $(el).text();
+        if (!text || text.length < 2) return;
+        
+        expect(_.find(text.split('\n'), (l) => l.match(/sourceMappingURL/))).to.be.ok;
+      });
     });
-  });
+  })
 });


### PR DESCRIPTION
This PR sets up electron-compile to automatically compile inline style and script tags in HTML documents. 

## Current MIME types supported

* `text/less` (in style tag) - LESS
* `text/scss` (in style tag) - SCSS
* `text/sass` (in style tag) - Sass
* `application/javascript` (in script tag) - ES6 (Babel)
* `application/coffeescript` (in script tag) - CoffeeScript
* `application/typescript` (in script tag) - TypeScript

#### What you write:

```html
<html>
  <style type="text/less">
  :host {
    display: flex;
    flex-direction: column;
    align-items: center;
    justify-content: center;
    height: 100%;
    
    // Note nested block that only works in LESS!
    ul {
      font-family: "MS Sans Serif";
    }
  }
  </style>

  <script>
  global.Polymer({
    is: 'loading-screen',
    properties: {
      screen: {
        type: String,
        reflectToAttribute: true
      }
    },
    
    // Note Arrow Function that only works in ES6!
    _emitRetry: () => {
      this.fire('retry');
    },

    _pageForScreen: (theScreen) => {
      return pageMap[theScreen];
    }
  });
  </script>
</html>
```

#### What Electron ends up seeing:

```html
<html>
  <style type="text/css">
:host {
  display: flex;
  flex-direction: column;
  align-items: center;
  justify-content: center;
  height: 100%;
}
:host ul {
  font-family: "MS Sans Serif";
}
  </style>
  <script type="application/javascript">
var _this = this;

global.Polymer({
  is: 'loading-screen',
  properties: {
    screen: {
      type: String,
      reflectToAttribute: true
    }
  },

  _emitRetry: function _emitRetry() {
    _this.fire('retry');
  },

  _pageForScreen: function _pageForScreen(theScreen) {
    return pageMap[theScreen];
  }
});
</script>
</html>
```